### PR TITLE
Remove Maiko submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "maiko"]
-	path = maiko
-	url = https://github.com/Interlisp/maiko.git


### PR DESCRIPTION
I was under the impression that Git submodules had improved; they have not. Submodules still require manual updates, effort on the part of the user to initialize them, and constant maintenance. There's such a thing as a "subtree," which might better fit our needs, but I'm going to scrap the whole idea for now because the advantages over cloning both repositories separately (or having an init script that does it for us) aren't clear.