### PR TITLE
Docker: run on non-x64, use ../maiko

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:focal
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y build-essential clang libx11-dev
-COPY maiko /build/
+RUN apt-get update && apt-get install -y make gcc libx11-dev
+COPY ../maiko/ /build/
 WORKDIR /build/bin
 RUN rm -rf /build/linux*
 RUN ./makeright x
@@ -14,11 +14,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 EXPOSE 5900
 
 RUN apt-get update && apt-get install -y tightvncserver
-RUN mkdir /app
+RUN mkdir -p /app/maiko
 WORKDIR /app
-COPY basics ./
-COPY --from=0 /build/linux.x86_64/* ./
+COPY ./* ./
+COPY --from=0 /build/bin ./maiko/bin
+COPY --from=0 /build/linux* ./maiko
 
 RUN adduser --disabled-password --gecos "" medley
 USER medley
-ENTRYPOINT USER=medley Xvnc -geometry 1270x720 :0 & DISPLAY=:0 /app/ldex -g 1280x720 full.sysout
+ENTRYPOINT USER=medley Xvnc -geometry 1280x720 :0 & DISPLAY=:0 PATH="/app/maiko:$PATH" ./run-medley -g 1280x720 -sc 1280x720


### PR DESCRIPTION
run-medley assumes that maiko/ will be organized neatly with the
executables in the correct (platform-specific) folder, but we don't know
what platform we're on when we're building via Docker (and I don't think
that we should need to). To deal with this, we just add the entire maiko
folder to the PATH rather than only the subdirectory corresponding to
the current platform.

Build is still two-stage.

Fixes part of #177.