### PR TITLE
Fix run-medley -dimensions processing to make sensible choices

### DIFF
--- a/run-medley
+++ b/run-medley
@@ -59,8 +59,15 @@ while [ "$#" -ne 0 ]; do
             shift
             ;;
         "--dimensions" | "-dimensions")
-            geometry="-g $2"
-            screensize="-sc $2"
+            sw=`expr "$2" : "\([0-9]*\)x[0-9]*$"`
+            sh=`expr "$2" : "[0-9]*x\([0-9]*\)$"`
+            if [ -n "$sw" -a -n "$sh" ] ; then
+                 sw=$(( (31+$sw)/32*32 ))
+                 gw=$(( 22+$sw ))
+                 gh=$(( 22+$sh ))
+                 geometry="-g ${gw}x${gh}"
+                 screensize="-sc ${sw}x${sh}"
+            fi
             shift
             ;;
         "--geometry" | "-geometry" | "-g")


### PR DESCRIPTION
Given a "-dimension WxH" argument, round up the W to a multiple of 32 for the
Lisp window width and use an X window geometry with an additional
22 pixels for both W and H to account for the current scrollbar size so that
the resulting X window will not require scrolling.