### PR TITLE
Docker: build with side-by-side medley and maiko dirs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ init.386/**
 # core files
 core
 *.core
+.git/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:focal
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y build-essential clang libx11-dev
-COPY maiko /build/
+RUN apt-get update && apt-get install -y make gcc libx11-dev
+COPY ../maiko/ /build/
 WORKDIR /build/bin
 RUN rm -rf /build/linux*
 RUN ./makeright x
@@ -14,11 +14,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 EXPOSE 5900
 
 RUN apt-get update && apt-get install -y tightvncserver
-RUN mkdir /app
+RUN mkdir -p /app/maiko
 WORKDIR /app
-COPY basics ./
-COPY --from=0 /build/linux.x86_64/* ./
+COPY ./* ./
+COPY --from=0 /build/bin ./maiko/bin
+COPY --from=0 /build/linux* ./maiko
 
 RUN adduser --disabled-password --gecos "" medley
 USER medley
-ENTRYPOINT USER=medley Xvnc -geometry 1270x720 :0 & DISPLAY=:0 /app/ldex -g 1280x720 full.sysout
+ENTRYPOINT USER=medley Xvnc -geometry 1280x720 :0 & DISPLAY=:0 PATH="/app/maiko:$PATH" ./run-medley -g 1280x720 -sc 1280x720

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:focal
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y make gcc libx11-dev
+RUN apt-get update && apt-get install -y make clang libx11-dev
 COPY ../maiko/ /build/
 WORKDIR /build/bin
 RUN rm -rf /build/linux*


### PR DESCRIPTION
I'd love for others to test these changes on their machines, because it seems that Docker is a bit more temperamental than I thought. The gist of this PR is that it makes Docker work with our new directory structure: to run a build, `medley/` and `maiko/` should be side-by-side in a directory, ideally by themselves, and you build with:

```bash
$ cd interlisp   # whichever directory contains medley/ and maiko/
$ docker build -f medley/Dockerfile . -t "interlisp/medley"
```

If you're on ARM, add `--platform linux/amd64` to the build command to build an x86_64 image.

Commit history is a little messy because of branch/merge problems, but I'll squash it before merging.