### PR TITLE
Loadup failure ldeinit

### DIFF
--- a/run-medley
+++ b/run-medley
@@ -172,18 +172,16 @@ export PATH="$MAIKODIR"/`osversion`.`machinetype`:"$oldpath"
 
 cd "$OLDPWD"
 
-whichprog=`which $prog`
-
-if [ -z "$whichprog" ] ; then
-    echo $prog not found
+if ! command -v "$prog" > /dev/null 2>&1; then
+    echo "$prog" not found
     exit 1
 fi
 
-echo "running: $whichprog $geometry $screensize $mem $passthrough_args $LDESRCESYSOUT"
+echo "running: $prog $geometry $screensize $mem $passthrough_args $LDESRCESYSOUT"
 echo "greet: $LDEINIT"
 
 export INMEDLEY=1
 
-$prog $geometry $screensize $mem -t "Medley Interlisp" $passthrough_args "$LDESRCESYSOUT"
+"$prog" $geometry $screensize $mem -t "Medley Interlisp" $passthrough_args "$LDESRCESYSOUT"
 
 

--- a/run-medley
+++ b/run-medley
@@ -172,9 +172,15 @@ export PATH="$MAIKODIR"/`osversion`.`machinetype`:"$oldpath"
 
 cd "$OLDPWD"
 
-echo "sysout is $LDESRCESYSOUT"
-echo "running `which $prog` $geometry $screensize $mem"
-echo "start $LDEINIT"
+whichprog=`which $prog`
+
+if [ -z "$whichprog" ] ; then
+    echo $prog not found
+    exit 1
+fi
+
+echo "running: $whichprog $geometry $screensize $mem $passthrough_args $LDESRCESYSOUT"
+echo "greet: $LDEINIT"
 
 export INMEDLEY=1
 

--- a/scripts/loadup-init.sh
+++ b/scripts/loadup-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+o#!/bin/sh
 
 export MEDLEYDIR=`pwd`
 
@@ -14,5 +14,5 @@ mkdir -p "$MEDLEYDIR/tmp"
 ./run-medley $scr -greet "$MEDLEYDIR"/sources/LOADUP-INIT.LISP -full
 
 echo ---- made ----
-ls -l tmp
+ls -l tmp/*[WMShlet]
 echo --------------

--- a/scripts/loadup-init.sh
+++ b/scripts/loadup-init.sh
@@ -1,4 +1,4 @@
-o#!/bin/sh
+#!/bin/sh
 
 export MEDLEYDIR=`pwd`
 

--- a/scripts/loadup-lisp-from-mid.sh
+++ b/scripts/loadup-lisp-from-mid.sh
@@ -13,6 +13,6 @@ scr="-sc 1024x768 -g 1042x790"
 ./run-medley $scr -greet $MEDLEYDIR/sources/LOADUP-LISP.CM tmp/init-mid.sysout
 
 echo ----- created: -------
-ls -l tmp/lisp.sysout tmp/lisp.dribble
+ls -l tmp/lisp.*[te]
 echo ----------------------
 


### PR DESCRIPTION
Fix up command checking in run-medley script.  Use `command -v` and handle case where program being executed has a space in the name.  Incorporates changes from LMM from previous version of this branch.