### PR TITLE
changes from #453 redone: NOGREET for run-medley, dummy HOME LOGINDIR for loadups

### DIFF
--- a/run-medley
+++ b/run-medley
@@ -54,7 +54,12 @@ export LDEKBDTYPE=x
 while [ "$#" -ne 0 ]; do
     case "$1" in
         "-nogreet" | "--nogreet")
-            export LDEINIT=""
+	    # Keep (GREET) from finding an init file
+	    mkdir -p $MEDLEYDIR/tmp/logindir
+	    export HOME=$MEDLEYDIR/tmp/logindir
+	    export LOGINDIR=$MEDLEYDIR/tmp/logindir
+
+            export LDEINIT="$MEDLEYDIR/greetfiles/NOGREET"
             ;;
         "-greet" | "--greet")
             export LDEINIT="$2"

--- a/scripts/loadup-all.sh
+++ b/scripts/loadup-all.sh
@@ -7,10 +7,6 @@ if [ ! -x run-medley ] ; then
     exit 1
 fi
 
-# set timestamp
-mkdir -p ./tmp
-touch ./tmp/loadup.timestamp
-
 ./scripts/loadup-init.sh && \
     ./scripts/loadup-mid-from-init.sh && \
     ./scripts/loadup-lisp-from-mid.sh && \

--- a/scripts/loadup-aux.sh
+++ b/scripts/loadup-aux.sh
@@ -9,6 +9,11 @@ fi
 
 touch tmp/loadup.timestamp
 
+# Keep (GREET) from finding an init file
+mkdir -p $MEDLEYDIR/tmp/logindir
+export HOME=$MEDLEYDIR/tmp/logindir
+export LOGINDIR=$MEDLEYDIR/tmp/logindir
+
 scr="-sc 1024x768 -g 1042x790"
 
 echo '" (IL:MEDLEY-INIT-VARS)(IL:LOAD(QUOTE MEDLEY-UTILS))(IL:MAKE-EXPORTS-ALL)(IL:MAKE-WHEREIS-HASH)(IL:LOGOUT T)"' > tmp/loadup-aux.cm

--- a/scripts/loadup-full-from-lisp.sh
+++ b/scripts/loadup-full-from-lisp.sh
@@ -10,6 +10,11 @@ scr="-sc 1024x768 -g 1042x790"
 
 touch tmp/loadup.timestamp
 
+# Keep (GREET) from finding an init file
+mkdir -p $MEDLEYDIR/tmp/logindir
+export HOME=$MEDLEYDIR/tmp/logindir
+export LOGINDIR=$MEDLEYDIR/tmp/logindir
+
 ./run-medley $scr -greet "$MEDLEYDIR/sources/LOADUP-FULL.CM" "$MEDLEYDIR/tmp/lisp.sysout"
 
 if [ tmp/full.sysout -nt tmp/loadup.timestamp ]; then

--- a/scripts/loadup-full.sh
+++ b/scripts/loadup-full.sh
@@ -6,6 +6,12 @@ if [ ! -x run-medley ] ; then
     echo must run from MEDLEYDIR ;
     exit 1 ;
 fi
+
+# Keep (GREET) from finding an init file
+mkdir -p $MEDLEYDIR/tmp/logindir
+export HOME=$MEDLEYDIR/tmp/logindir
+export LOGINDIR=$MEDLEYDIR/tmp/logindir
+
 scr="-sc 1024x768 -g 1042x790"
 
 touch tmp/loadup.timestamp

--- a/scripts/loadup-init.sh
+++ b/scripts/loadup-init.sh
@@ -9,7 +9,11 @@ fi
 
 scr="-sc 1024x768 -g 1042x790"
 
-mkdir -p "$MEDLEYDIR/tmp"
+# Keep (GREET) from finding an init file
+mkdir -p $MEDLEYDIR/tmp/logindir
+export HOME=$MEDLEYDIR/tmp/logindir
+export LOGINDIR=$MEDLEYDIR/tmp/logindir
+
 touch tmp/loadup.timestamp
 
 ./run-medley $scr -greet "$MEDLEYDIR"/sources/LOADUP-INIT.LISP loadups/starter.sysout


### PR DESCRIPTION
when doing loadups, remove all paths to find the INIT file for the person doing the loadup.
When doing run-medley -nogreet also supply NOGREET as the site init file.
