### PR TITLE
Stop-gap NOGREET for use with run-medley -nogreet

### DIFF
--- a/greetfiles/NOGREET
+++ b/greetfiles/NOGREET
@@ -1,0 +1,19 @@
+(DEFINE-FILE-INFO PACKAGE "INTERLISP" READTABLE "INTERLISP" BASE 10)
+(FILECREATED "10-Sep-2021 21:25:42" {DSK}<home>larry>medley>greetfiles>NOGREET.;1 537    )
+
+
+(PRETTYCOMPRINT NOGREETCOMS)
+
+(RPAQQ NOGREETCOMS [(P (COND ((STKPOS 'GREET)
+                                  (SETQ USERGREETFILES NIL)
+                                  (CLOSEF? (INPUT))
+                                  (RETFROM 'GREET])
+
+[COND
+   ((STKPOS 'GREET)
+    (SETQ USERGREETFILES NIL)
+    (CLOSEF? (INPUT))
+    (RETFROM 'GREET]
+(DECLARE%: DONTCOPY
+  (FILEMAP (NIL)))
+STOP


### PR DESCRIPTION
somehow this file got left out and code in run-medley expects it
#462 has some discussion
