### PR TITLE
run-medley improvements

### DIFF
--- a/greetfiles/NOGREET
+++ b/greetfiles/NOGREET
@@ -1,0 +1,19 @@
+(DEFINE-FILE-INFO PACKAGE "INTERLISP" READTABLE "INTERLISP" BASE 10)
+(FILECREATED "10-Sep-2021 21:25:42" {DSK}<home>larry>medley>greetfiles>NOGREET.;1 537    )
+
+
+(PRETTYCOMPRINT NOGREETCOMS)
+
+(RPAQQ NOGREETCOMS [(P (COND ((STKPOS 'GREET)
+                                  (SETQ USERGREETFILES NIL)
+                                  (CLOSEF? (INPUT))
+                                  (RETFROM 'GREET])
+
+[COND
+   ((STKPOS 'GREET)
+    (SETQ USERGREETFILES NIL)
+    (CLOSEF? (INPUT))
+    (RETFROM 'GREET]
+(DECLARE%: DONTCOPY
+  (FILEMAP (NIL)))
+STOP

--- a/run-medley
+++ b/run-medley
@@ -1,16 +1,18 @@
 #!/bin/sh
 #               Run Medley
 #
-# Syntax: run-medley [--dimensions WIDTHxHEIGHT] \  sets both -g -sc
-#                    [-g WIDTHxHEIGHT]           \
-#                    [-sc WIDTHxHEIGHT]          \
-#                    [--display X_DISPLAY]       \
-#                    [--vmem | --vmfile FILE]    \
-#                    [--nogreet | --greet FILE]  \
-#                    [-n | -nl | 
-#                    [URL_OR_FILE]
+# Syntax: run-medley [--dimensions WIDTHxHEIGHT] #  sets both -g -sc
+#                    [-g WIDTHxHEIGHT]
+#                    [-sc WIDTHxHEIGHT]
+#                    [--display X_DISPLAY]       # defaults to $DISPLAY or :0
+#                    [-prog LDEFILE]
+#                    [--vmem | --vmfile FILE]
+#                    [--nogreet | --greet FILE |
+#                           --loadup FILE ]      # will separate from GREET
+#                    [-n | -nl | -full | -lisp |  
+#                    [SYSOUTFILE]
 
-# Directory variables are accessible from Lisp via UNIX-GETENV
+# Variables accessible from Lisp via UNIX-GETENV
 # LDESRCESYSOUT         SYSOUT full-file name you want to run
 # LDEDESTSYSOUT         name for destination of SaveVM/LOGOUT
 # MEDLEYDIR             used by init file to set other path variables
@@ -53,6 +55,12 @@ export LDEKBDTYPE=x
 
 while [ "$#" -ne 0 ]; do
     case "$1" in
+	"-loadup")
+	    export MEDLEYLOADUP="$2"
+	    export LDEINIT="$2"
+	    shift
+	    ;;
+	
         "-nogreet" | "--nogreet")
 	    # Keep (GREET) from finding an init file
 	    mkdir -p $MEDLEYDIR/tmp/logindir
@@ -141,12 +149,6 @@ if [ -z "$geometry" ] ; then
     screensize="-sc 1440x900"
 fi
 
-case "$LDESRCSYSOUT" in
-    "http:*" | "https:*")
-    echo URL not supported yet
-    exit 1
-esac
-
 inferred_maikodir=false
 
 if [ -z "$MAIKODIR" ] ; then
@@ -168,18 +170,24 @@ if [ ! -d "$MAIKODIR/bin" ] ; then
     exit 1
 fi
 
-
-oldpath="$PATH"
-
-export PATH=.:"$PATH"
-cd "$MAIKODIR"/bin
-export PATH="$MAIKODIR"/`osversion`.`machinetype`:"$oldpath"
-
-cd "$OLDPWD"
+# if lde is already on path, don't reset it
 
 if ! command -v "$prog" > /dev/null 2>&1; then
-    echo "$prog" not found
-    exit 1
+    oldpath="$PATH"
+    oldpwd=`pwd`
+    PATH=.:"$PATH"
+    cd "$MAIKODIR"/bin
+    osv=`osversion`
+    mct=`machinetype`
+    newpath="$MAIKODIR"/"$osv.$mct"
+    PATH="$newpath":"$oldpath"
+    cd "$oldpwd"
+    if ! command -v $prog > /dev/null 2>&1; then
+	echo $prog not found in $newpath
+	echo osversion = $osv
+	echo machinetype = $mct
+	exit 1
+    fi
 fi
 
 echo "running: $prog $geometry $screensize $mem $passthrough_args $LDESRCESYSOUT"

--- a/scripts/loadup-aux.sh
+++ b/scripts/loadup-aux.sh
@@ -17,7 +17,7 @@ export LOGINDIR=$MEDLEYDIR/tmp/logindir
 scr="-sc 1024x768 -g 1042x790"
 
 echo '" (IL:MEDLEY-INIT-VARS)(IL:LOAD(QUOTE MEDLEY-UTILS))(IL:MAKE-EXPORTS-ALL)(IL:MAKE-WHEREIS-HASH)(IL:LOGOUT T)"' > tmp/loadup-aux.cm
-./run-medley $scr -greet "$MEDLEYDIR"/tmp/loadup-aux.cm tmp/full.sysout
+./run-medley $scr -loadup "$MEDLEYDIR"/tmp/loadup-aux.cm tmp/full.sysout
 
 if [ tmp/whereis.hash -nt tmp/loadup.timestamp ]; then
     

--- a/scripts/loadup-full-from-lisp.sh
+++ b/scripts/loadup-full-from-lisp.sh
@@ -15,7 +15,7 @@ mkdir -p $MEDLEYDIR/tmp/logindir
 export HOME=$MEDLEYDIR/tmp/logindir
 export LOGINDIR=$MEDLEYDIR/tmp/logindir
 
-./run-medley $scr -greet "$MEDLEYDIR/sources/LOADUP-FULL.CM" "$MEDLEYDIR/tmp/lisp.sysout"
+./run-medley $scr -loadup "$MEDLEYDIR/sources/LOADUP-FULL.CM" "$MEDLEYDIR/tmp/lisp.sysout"
 
 if [ tmp/full.sysout -nt tmp/loadup.timestamp ]; then
     

--- a/scripts/loadup-full.sh
+++ b/scripts/loadup-full.sh
@@ -16,7 +16,7 @@ scr="-sc 1024x768 -g 1042x790"
 
 touch tmp/loadup.timestamp
 
-./run-medley $scr -greet "$MEDLEYDIR/sources/LOADUP-FULL.CM" "$MEDLEYDIR/loadups/lisp.sysout"
+./run-medley $scr -loadup "$MEDLEYDIR/sources/LOADUP-FULL.CM" "$MEDLEYDIR/loadups/lisp.sysout"
 
 if [ tmp/full.sysout -nt tmp/loadup.timestamp ]; then
     

--- a/scripts/loadup-init.sh
+++ b/scripts/loadup-init.sh
@@ -16,7 +16,7 @@ export LOGINDIR=$MEDLEYDIR/tmp/logindir
 
 touch tmp/loadup.timestamp
 
-./run-medley $scr -greet "$MEDLEYDIR"/sources/LOADUP-INIT.LISP loadups/starter.sysout
+./run-medley $scr -loadup "$MEDLEYDIR"/sources/LOADUP-INIT.LISP loadups/starter.sysout
 
 if [ tmp/init.dlinit -nt tmp/loadup.timestamp ]; then
     

--- a/scripts/loadup-lisp-from-mid.sh
+++ b/scripts/loadup-lisp-from-mid.sh
@@ -12,7 +12,7 @@ touch tmp/loadup.timestamp
 scr="-sc 1024x768 -g 1042x790"
 
 
-./run-medley $scr -greet "$MEDLEYDIR/sources/LOADUP-LISP.CM" tmp/init-mid.sysout
+./run-medley $scr -loadup "$MEDLEYDIR/sources/LOADUP-LISP.CM" tmp/init-mid.sysout
 
 if [ tmp/lisp.sysout -nt tmp/loadup.timestamp ]; then
     

--- a/scripts/loadup-mid-from-init.sh
+++ b/scripts/loadup-mid-from-init.sh
@@ -12,7 +12,7 @@ touch tmp/loadup.timestamp
 
 scr="-sc 1024x768 -g 1042x790"
 
-./run-medley -prog ldeinit -greet $MEDLEYDIR/sources/XREM.CM $scr -vmem tmp/init-mid.sysout tmp/init.dlinit
+./run-medley -prog ldeinit -loadup $MEDLEYDIR/sources/XREM.CM $scr -vmem tmp/init-mid.sysout tmp/init.dlinit
 
 
 echo 


### PR DESCRIPTION
* if lde is on path, don't override
* if it doesn't find os.machine combo be more explicit (pi4 64 case)
* add a -loadup flag which sets an environment variable
* use -loadup instead of -greet in loadup scripts
