### PR TITLE
Add -noscroll option to run-medley; turns off scollbars

### DIFF
--- a/run-medley
+++ b/run-medley
@@ -2,6 +2,7 @@
 #               Run Medley
 #
 # Syntax: run-medley [--dimensions WIDTHxHEIGHT] #  sets both -g -sc
+#                    [-noscroll]                 #  sc = gw x gh+16
 #                    [-g WIDTHxHEIGHT]
 #                    [-sc WIDTHxHEIGHT]
 #                    [--display X_DISPLAY]       # defaults to $DISPLAY or :0
@@ -38,6 +39,8 @@ fi
 prog="lde"
 passthrough_args=""
 mem="-m 256"
+scroll=22
+noscroll=""
 
 if [ -z "$LDEDESTSYSOUT" ] ; then
     if [ -z "$LOGINDIR" ] ; then
@@ -71,13 +74,17 @@ while [ "$#" -ne 0 ]; do
             export LDEINIT="$2"
             shift
             ;;
+        "-noscroll")
+	    scroll=0
+	    noscroll="-noscroll"
+	    ;;
         "--dimensions" | "-dimensions")
             sw=`expr "$2" : "\([0-9]*\)x[0-9]*$"`
             sh=`expr "$2" : "[0-9]*x\([0-9]*\)$"`
             if [ -n "$sw" -a -n "$sh" ] ; then
                  sw=$(( (31+$sw)/32*32 ))
-                 gw=$(( 22+$sw ))
-                 gh=$(( 22+$sh ))
+                 gw=$(( $scroll+$sw ))
+                 gh=$(( $scroll+$sh ))
                  geometry="-g ${gw}x${gh}"
                  screensize="-sc ${sw}x${sh}"
             fi
@@ -180,11 +187,11 @@ if ! command -v "$prog" > /dev/null 2>&1; then
     fi
 fi
 
-echo "running: $prog $geometry $screensize $mem $passthrough_args $LDESRCESYSOUT"
+echo "running: $prog $noscroll $geometry $screensize $mem $passthrough_args $LDESRCESYSOUT"
 echo "greet: $LDEINIT"
 
 export INMEDLEY=1
 
-"$prog" $geometry $screensize $mem -t "Medley Interlisp" $passthrough_args "$LDESRCESYSOUT"
+"$prog" $noscroll $geometry $screensize $mem -t "Medley Interlisp" $passthrough_args "$LDESRCESYSOUT"
 
 

--- a/run-medley
+++ b/run-medley
@@ -1,8 +1,8 @@
 #!/bin/sh
 #               Run Medley
 #
-# Syntax: run-medley [--dimensions WIDTHxHEIGHT] #  sets both -g -sc
-#                    [-noscroll]                 #  sc = gw x gh+16
+# Syntax: run-medley [-noscroll]                 #turn off scrollbars
+#                    [--dimensions WIDTHxHEIGHT] #  sets both -g -sc
 #                    [-g WIDTHxHEIGHT]
 #                    [-sc WIDTHxHEIGHT]
 #                    [--display X_DISPLAY]       # defaults to $DISPLAY or :0
@@ -68,6 +68,7 @@ while [ "$#" -ne 0 ]; do
 	    mkdir -p $MEDLEYDIR/tmp/logindir
 	    export HOME=$MEDLEYDIR/tmp/logindir
 	    export LOGINDIR=$MEDLEYDIR/tmp/logindir
+
             export LDEINIT="$MEDLEYDIR/greetfiles/NOGREET"
             ;;
         "-greet" | "--greet")


### PR DESCRIPTION
use BEFORE -dimensions to not add a margin.