### PR TITLE
Updated Docker build to use Medley Release Assets

### DIFF
--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -3,11 +3,13 @@
 # Interlisp workflow to build Docker Image that support multiple architectures
 name: Build Medley Docker image
 
-# Run this workflow on push to master
+# Run this workflow on demand
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
+
+#  push:
+#    branches:
+#      - master
 
 # Jobs that compose this workflow
 jobs:
@@ -29,14 +31,14 @@ jobs:
 
           # If this is git tag, use the tag name as a docker tag
           if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
+            VERSION=${GITHUB_REF#refs/tags/}
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${SHORTREF}"
 
-          # If the VERSION looks like a version number, assume that
+          # If the VERSION looks like medley followed by a date, assume that
           # this is the most recent version of the image and also
           # tag it 'latest'.
-          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+          if [[ $VERSION =~ ^medley-[0-9]{1,6}.$ ]]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:latest"
           fi
 
@@ -44,6 +46,16 @@ jobs:
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
           echo ::set-output name=build_time::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo ::set-output name=version::${VERSION}
+
+      # Download Medley Release Assets
+      - name: Download Release Assets
+        uses: robinraju/release-downloader@v1.2
+        with:
+          repository: Interlisp/medley
+          token: ${{ secrets.GITHUB_TOKEN }}
+          latest: true
+          fileName: "*"
 
       # Setup Docker Machine Emulation environment
       - name: Set up QEMU

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -10,7 +10,21 @@ Originally done only with shell scripts:
 
 In the github medley repository (Interlisp/medley) go to the Actions tab. 
 
-It should list the available github actions, select the bottom one, Build Medley Release. 
+It will list the available github actions, select: **Build Medley Release**. 
 
 In the middle of the screen there's a box labeled workflow runs.
 There should be a row in it that states 'This workflow has a workflow_dispatch event trigger' with a drop down menu (it really looks more like a button) on the right side labeled 'Run workflow'.  Select that and you'll get a form allowing you to select the branch (I've only used Master) and enter the release name.  Enter a name or leave it empty and press the green 'Run workflow' button. The workflow should queue up and run.  
+
+# How to create a Docker image for the latest Medley release
+
+In the github medley repository (Interlisp/medley) go to the Actions tab. 
+
+It will list the available github actions, select: **Build Medley Docker image**. 
+
+A table is presented which lists the previous runs of the workflow.  If the workflow has never been run, it will be empty.  A the top of the list is a row labeled, 'This workflow has a workflow_dispatch event trigger.' with a drop down menu labeled 'Run workflow'.  Select it.
+
+A box will be presented asking, 'Use workflow from' with a drop down menu of all available branches.  The default branch is **master**.  Leave it selected and push the green 'Run workflow' button.
+
+The workflow will be queued to run and start running.
+
+The workflow pulls the latest Maiko image from Docker Hub and the Release Assets from the latest Medley release, generally defined as medley-YYMMDD.  The Medley Docker image adds in Tight VNC Server and retrieves the two tarballs associated with a release, one containing the sysouts and the other the other needed files source, fonts, etc.  The contents are uncompressed and loaded into the Medley directory structure.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM interlisp/maiko:latest
 ARG BUILD_DATE
 LABEL name="Medley"
+# LABEL tags=${tags}
 LABEL description="The Medley Interlisp environment"
 LABEL url="https://github.com/Interlisp/medley"
 LABEL build-time=$BUILD_DATE
@@ -9,8 +10,8 @@ RUN apt-get update && apt-get install -y tightvncserver
 
 EXPOSE 5900
 
-# Need to refine this down to only needed directories.
-COPY . /app/medley
+# Copy and uncompress loadup and required source files.
+ADD *.tgz /app
 
 WORKDIR /app/medley
 


### PR DESCRIPTION
- Update Docker Build to use Medley Release Assets
- Change github action to run on demand
- Update build documentation adding initial description of how to build the Docker images.

Addresses #177,  #514 and #515 