### PR TITLE
Update to use Maiko release artifacts

### DIFF
--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -27,24 +27,37 @@ jobs:
       - name: Checkout Medley
         uses: actions/checkout@v2
 
-      - name: Get the latest Maiko Release
-        uses: actions/checkout@v2
+      # Get Maiko release information, retrieves the name of the latest
+      # release.  Used to download the correct Maiko release
+      - name: Get Maiko Release Information
+        id: latest_version
+        uses: abatilo/release-info-action@v1.3.0
         with:
-          repository: interlisp/maiko
-          path: maiko
+          owner: Interlisp
+          repo: maiko
+          
+      # Download Maiko Release Assets
+      - name: Download Release Assets
+        uses: robinraju/release-downloader@v1.2
+        with:
+          repository: Interlisp/maiko
+          token: ${{ secrets.GITHUB_TOKEN }}
+          latest: true
+          fileName: "${{ steps.latest_version.outputs.latest_tag }}-linux.x86_64.tgz" 
 
-      - name: install compiler
-        run: sudo apt-get update && sudo apt-get install -y make clang libx11-dev gcc x11vnc xvfb
+      - name: Untar Maiko Release
+        run: |
+          tar -xvzf "${{ steps.latest_version.outputs.latest_tag }}-linux.x86_64.tgz"
 
       - name: install vnc
-        run: sudo apt-get install -y tightvncserver
-
-      - name: Compile Maiko
-        working-directory: maiko/bin
-        run: ./makeright  x && ./makeright init
+        run: sudo apt-get update && sudo apt-get install -y tightvncserver
 
       - name: Build Loadout
-        run: pwd && Xvnc -once -geometry 1280x720 :0 & DISPLAY=:0 PATH="/maiko:$PATH" scripts/loadup-all.sh
+        run: |
+          Xvnc -geometry 1280x720 :0 &
+          export DISPLAY=":0"
+          PATH="$PWD/maiko:$PATH" 
+          scripts/loadup-all.sh
 
       - name: Build release tar get libs
         run: |
@@ -81,13 +94,13 @@ jobs:
 
       - name: Release notes
         run: |
-          sed s/'$tag'/$tag/g < release-notes.md > tmp/release-notes.md  &&
-          ls tmp && env
+          sed s/'$tag'/$tag/g < release-notes.md > tmp/release-notes.md
       
       - name: push the release
         uses: ncipollo/release-action@v1.8.10
         with: 
           artifacts: tmp/${{ env.tag }}-loadups.tgz,tmp/${{ env.tag }}-runtime.tgz
           tag: ${{ env.tag }}
+          draft: true
           bodyfile: tmp/release-notes.md
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Use latest Maiko release binaries to build Medley loadups. 
- Set release to DRAFT