### PR TITLE
Add Maiko Release to tags.  Install Maiko from Release assets.

### DIFF
--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -7,10 +7,6 @@ name: Build Medley Docker image
 on:
   workflow_dispatch:
 
-#  push:
-#    branches:
-#      - master
-
 # Jobs that compose this workflow
 jobs:
   # Job to build the docker image
@@ -21,27 +17,34 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      # Get the Medley Release Information
+      - name: Get Medley Release Information
+        id: medley_version
+        uses: abatilo/release-info-action@v1.3.0
+        with:
+          owner: Interlisp
+          repo: medley
+
+      # Get the Maiko Release Information
+      - name: Get Maiko Release Information
+        id: maiko_version
+        uses: abatilo/release-info-action@v1.3.0
+        with:
+          owner: Interlisp
+          repo: maiko
+
       # Setup needed environment variables
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=interlisp/${GITHUB_REPOSITORY#*/}
+          DOCKERHUB_ACCOUNT=interlisp
+          DOCKER_IMAGE=${DOCKERHUB_ACCOUNT}/${GITHUB_REPOSITORY#*/}
           VERSION=latest
-          SHORTREF=${GITHUB_SHA::8}
+          MAIKO_RELEASE=${{ steps.maiko_version.outputs.latest_tag }}
+          MEDLEY_RELEASE=${{ steps.medley_version.outputs.latest_tag }}
 
-          # If this is git tag, use the tag name as a docker tag
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          fi
-          TAGS="${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${SHORTREF}"
-
-          # If the VERSION looks like medley followed by a date, assume that
-          # this is the most recent version of the image and also
-          # tag it 'latest'.
-          if [[ $VERSION =~ ^medley-[0-9]{1,6}.$ ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest"
-          fi
-
+          TAGS="${DOCKER_IMAGE}:${MEDLEY_RELEASE},${DOCKER_IMAGE}:${VERSION},${DOCKER_IMAGE}:${MAIKO_RELEASE}"
+          
           # Set output parameters.
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
@@ -53,6 +56,15 @@ jobs:
         uses: robinraju/release-downloader@v1.2
         with:
           repository: Interlisp/medley
+          token: ${{ secrets.GITHUB_TOKEN }}
+          latest: true
+          fileName: "*"
+
+      # Download Maiko Release Assets
+      - name: Download Release Assets
+        uses: robinraju/release-downloader@v1.2
+        with:
+          repository: Interlisp/maiko
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: true
           fileName: "*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM interlisp/maiko:latest
+FROM ubuntu:focal
 ARG BUILD_DATE
 LABEL name="Medley"
 # LABEL tags=${tags}


### PR DESCRIPTION
This finishes up the cleanup work for the GitHub Medley build.  The resulting Docker image should have the desired set of tags #516  and address the concerns in #177 

[Building Maiko and Medley with GitHub Actions](https://github.com/Interlisp/medley/wiki/Building-Maiko-and-Medley-with-GitHub-Actions) still needs to be updated to bring the document inline with the updates.

