### PR TITLE
Fixing up confusion between Docker username and Docker namespaces.  Fix for Docker login issues?

### DIFF
--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -125,9 +125,9 @@ jobs:
           REPO_NAME=${GITHUB_REPOSITORY#*/}
           echo "REPO_NAME=${REPO_NAME}" >> ${GITHUB_ENV}
           echo ::set-output name=repo_name::${REPO_NAME}
-          DOCKER_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          echo "DOCKER_OWNER=${DOCKER_OWNER}" >> ${GITHUB_ENV}
-          echo ::set-output name=docker_owner::${DOCKER_OWNER}
+          DOCKER_NAMESPACE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "DOCKER_NAMESPACE=${DOCKER_NAMESPACE}" >> ${GITHUB_ENV}
+          echo ::set-output name=docker_namespace::${DOCKER_NAMESPACE}
 
       # Get tag of latest Medley release.
       - name: Get Medley Release Information
@@ -151,8 +151,8 @@ jobs:
       - name: Get info from latest Maiko image
         id: maiko_setup
         run: |
-          docker pull ${DOCKER_OWNER}/maiko:latest
-          MAIKO_RELEASE=$(docker run --entrypoint /bin/bash ${DOCKER_OWNER}/maiko:latest -c "echo \${MAIKO_RELEASE}")
+          docker pull ${DOCKER_NAMESPACE}/maiko:latest
+          MAIKO_RELEASE=$(docker run --entrypoint /bin/bash ${DOCKER_NAMESPACE}/maiko:latest -c "echo \${MAIKO_RELEASE}")
           echo "MAIKO_RELEASE=${MAIKO_RELEASE}" >> ${GITHUB_ENV}
           echo ::set-output name=maiko_release::${MAIKO_RELEASE}
 
@@ -161,7 +161,7 @@ jobs:
         id: setup_env
         run: |
           RELEASE_TAG=${{ steps.release_info.outputs.latest_tag }}
-          DOCKER_IMAGE=${DOCKER_OWNER}/${REPO_NAME}
+          DOCKER_IMAGE=${DOCKER_NAMESPACE}/${REPO_NAME}
           DOCKER_TAGS="${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:${RELEASE_TAG#*-}_${MAIKO_RELEASE#*-}"
           echo ::set-output name=docker_tags::${DOCKER_TAGS}
           echo ::set-output name=docker_image::${DOCKER_IMAGE}
@@ -184,7 +184,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ steps.repo_env.outputs.docker_owner }}
+          username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       # Do the Docker Build using the Dockerfile in the repository
@@ -198,7 +198,7 @@ jobs:
             BUILD_DATE=${{ steps.setup_env.outputs.build_time }}
             RELEASE_TAG=${{ steps.setup_env.outputs.release_tag }}
             MAIKO_RELEASE=${{ steps.setup_env.outputs.maiko_release }}
-            DOCKER_OWNER=${{ steps.repo_env.outputs.docker_owner }}
+            DOCKER_NAMESPACE=${{ steps.repo_env.outputs.docker_namespace }}
             REPO_OWNER=${{ github.repository_owner }}
           context: ./release_tars
           file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@
 #
 # ******************************************************************************
 
-ARG DOCKER_OWNER=interlisp
+ARG DOCKER_NAMESPACE=interlisp
 
-FROM ${DOCKER_OWNER}/maiko:latest
+FROM ${DOCKER_NAMESPACE}/maiko:latest
 
 # Add tightvnc server to the image
 RUN apt-get update && apt-get install -y tightvncserver
@@ -31,6 +31,9 @@ ENV MEDLEY_RELEASE=$RELEASE_TAG
 
 ARG INSTALL_LOCATION=/usr/local/interlisp
 ENV INSTALL_LOCATION=${INSTALL_LOCATION}
+
+ARG DOCKER_NAMESPACE=interlisp
+ENV DOCKER_NAMESPACE=${DOCKER_NAMESPACE}
 
 # Copy over the release tars
 RUN mkdir -p ${INSTALL_LOCATION}


### PR DESCRIPTION
Take away my Docker merit badge.  I had a built in confusion between Docker namespaces and Docker login usernames.  On my test fork, they are the same - but of course in general they are not.

This fix cleans this up and add some better variable naming to make it clear.

Hopefully this will fix the Docker login issues with buildDocker.yml.
