### PR TITLE
Fix inputs: clause in buildDocker.yml

### DIFF
--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -20,12 +20,13 @@ name: 'Build/Push Docker Image'
 # Run this workflow on ...
 on:
   workflow_dispatch:
-    force:
-      description: "Force build even if build already successfully completed for this commit"
-      type: choice
-      options:
-      - 'false'
-      - 'true'
+    inputs: 
+      force:
+        description: "Force build even if build already successfully completed for this commit"
+        type: choice
+        options:
+        - 'false'
+        - 'true'
   
   workflow_call:
     outputs:


### PR DESCRIPTION
buildDocker.yml (aka the Build/Push Docker Image action) was not handling the "force" input correctly.  This fixes that and now can force a Medley docker build even if the sentry says it has already been built.