### PR TITLE
loadup and run-medley script bug fixes

### DIFF
--- a/run-medley
+++ b/run-medley
@@ -59,6 +59,10 @@ export LDEKBDTYPE=x
 while [ "$#" -ne 0 ]; do
     case "$1" in
 	"-loadup")
+	    # Keep (GREET) from finding adifferent init file
+	    mkdir -p $MEDLEYDIR/tmp/logindir
+	    export LOGINDIR=$MEDLEYDIR/tmp/logindir
+
 	    export MEDLEYLOADUP="$2"
 	    export LDEINIT="$2"
 	    shift
@@ -120,7 +124,7 @@ while [ "$#" -ne 0 ]; do
         "-lisp")
             export LDESRCESYSOUT="$MEDLEYDIR/loadups/lisp.sysout"
             ;;
-        "-N" | "-new" | "-newfull" )
+        "-n" | "-new" | "-newfull" )
             export LDESRCESYSOUT="$MEDLEYDIR/tmp/full.sysout"
             ;;
         "-nl" | "-newlisp" )

--- a/scripts/loadup-all.sh
+++ b/scripts/loadup-all.sh
@@ -14,7 +14,7 @@ fi
     ./scripts/loadup-aux.sh
 
 echo "loadups are in $MEDLEYDIR/tmp"
-edho use
+echo use
 echo "   ./scripts/copy-all.sh   "
 echo "to copy to loadups library"
 echo "**** DONE ****"

--- a/scripts/loadup-all.sh
+++ b/scripts/loadup-all.sh
@@ -11,11 +11,14 @@ fi
     ./scripts/loadup-mid-from-init.sh && \
     ./scripts/loadup-lisp-from-mid.sh && \
     ./scripts/loadup-full-from-lisp.sh && \
-    ./scripts/loadup-aux.sh && \
-    ./scripts/copy-all.sh && \
-    ls -l loadups/*.sysout loadups/whereis.hash library/exports.all && \
-    echo "**** DONE ****"
-    
+    ./scripts/loadup-aux.sh
+
+echo "loadups are in $MEDLEYDIR/tmp"
+edho use
+echo "   ./scripts/copy-all.sh   "
+echo "to copy to loadups library"
+echo "**** DONE ****"
+
 
 
 

--- a/scripts/loadup-and-release.sh
+++ b/scripts/loadup-and-release.sh
@@ -8,6 +8,5 @@ if [ ! -x run-medley ] ; then
 fi
 
 ./scripts/loadup-all.sh  &&  \
-    ./scripts/copy-all.sh && \
     ./scripts/release-medley.sh
 

--- a/scripts/loadup-aux.sh
+++ b/scripts/loadup-aux.sh
@@ -9,11 +9,6 @@ fi
 
 touch tmp/loadup.timestamp
 
-# Keep (GREET) from finding an init file
-mkdir -p $MEDLEYDIR/tmp/logindir
-export HOME=$MEDLEYDIR/tmp/logindir
-export LOGINDIR=$MEDLEYDIR/tmp/logindir
-
 scr="-sc 1024x768 -g 1042x790"
 
 echo '" (IL:MEDLEY-INIT-VARS)(IL:LOAD(QUOTE MEDLEY-UTILS))(IL:MAKE-EXPORTS-ALL)(IL:MAKE-WHEREIS-HASH)(IL:LOGOUT T)"' > tmp/loadup-aux.cm

--- a/scripts/loadup-db.sh
+++ b/scripts/loadup-db.sh
@@ -9,11 +9,6 @@ fi
 
 touch tmp/loadup.timestamp
 
-# Keep (GREET) from finding an init file
-mkdir -p $MEDLEYDIR/tmp/logindir
-export HOME=$MEDLEYDIR/tmp/logindir
-export LOGINDIR=$MEDLEYDIR/tmp/logindir
-
 scr="-sc 1024x768 -g 1042x790"
 
 echo '" (IL:MEDLEY-INIT-VARS)(IL:FILESLOAD MEDLEY-UTILS)(IL:MAKE-FULLER-DB)(IL:LOGOUT T)"' > tmp/loadup-db.cm

--- a/scripts/loadup-full-from-lisp.sh
+++ b/scripts/loadup-full-from-lisp.sh
@@ -10,11 +10,6 @@ scr="-sc 1024x768 -g 1042x790"
 
 touch tmp/loadup.timestamp
 
-# Keep (GREET) from finding an init file
-mkdir -p $MEDLEYDIR/tmp/logindir
-export HOME=$MEDLEYDIR/tmp/logindir
-export LOGINDIR=$MEDLEYDIR/tmp/logindir
-
 ./run-medley $scr -loadup "$MEDLEYDIR/sources/LOADUP-FULL.CM" "$MEDLEYDIR/tmp/lisp.sysout"
 
 if [ tmp/full.sysout -nt tmp/loadup.timestamp ]; then

--- a/scripts/loadup-full.sh
+++ b/scripts/loadup-full.sh
@@ -7,25 +7,9 @@ if [ ! -x run-medley ] ; then
     exit 1 ;
 fi
 
-# Keep (GREET) from finding an init file
-mkdir -p $MEDLEYDIR/tmp/logindir
-export HOME=$MEDLEYDIR/tmp/logindir
-export LOGINDIR=$MEDLEYDIR/tmp/logindir
 
-scr="-sc 1024x768 -g 1042x790"
+    ./scripts/loadup-init.sh && \
+    ./scripts/loadup-mid-from-init.sh && \
+    ./scripts/loadup-lisp-from-mid.sh && \
+    ./scripts/loadup-full-from-lisp.sh
 
-touch tmp/loadup.timestamp
-
-./run-medley $scr -loadup "$MEDLEYDIR/sources/LOADUP-FULL.CM" "$MEDLEYDIR/loadups/lisp.sysout"
-
-if [ tmp/full.sysout -nt tmp/loadup.timestamp ]; then
-    
-    echo ---- made ----
-    ls -l tmp/full.*
-    echo --------------
-
-else
-    echo XXXXX FAILURE XXXXX
-    ls -l tmp/full.*
-    exit 1
-fi

--- a/scripts/loadup-init.sh
+++ b/scripts/loadup-init.sh
@@ -9,11 +9,6 @@ fi
 
 scr="-sc 1024x768 -g 1042x790"
 
-# Keep (GREET) from finding an init file
-mkdir -p $MEDLEYDIR/tmp/logindir
-export HOME=$MEDLEYDIR/tmp/logindir
-export LOGINDIR=$MEDLEYDIR/tmp/logindir
-
 touch tmp/loadup.timestamp
 
 ./run-medley $scr -loadup "$MEDLEYDIR"/sources/LOADUP-INIT.LISP loadups/starter.sysout


### PR DESCRIPTION
* run-medley put back -n option
* loadup-all.sh put back leaving files in tmp (not calling copy-all)
* loadup-full.sh is now like loadup-all without loadup-aux (making whereis.hash and exports.all)
* run-medley -loadup has common logic for -nogreet (reset LOGINDIR).
