### PR TITLE
Make /usr/local/bin/medley run the right 'real' medley

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ ADD ./*.tgz ${INSTALL_LOCATION}
 
 # Create a run_medley script in /usr/local/bin
 RUN mkdir -p /usr/local/bin                                     && \
-    echo "#!/bin/bash"              > /usr/local/bin/run-medley && \
-    echo "cd ${INSTALL_LOCATION}"  >> /usr/local/bin/run-medley && \
-    echo './run-medley "$@"'       >> /usr/local/bin/run-medley && \
+    echo "#!/bin/bash"                    > /usr/local/bin/run-medley && \
+    echo "cd ${INSTALL_LOCATION}/medley"  >> /usr/local/bin/run-medley && \
+    echo './run-medley "$@"'              >> /usr/local/bin/run-medley && \
     chmod ugo+x /usr/local/bin/run-medley
     
 # "Finalize" image


### PR DESCRIPTION
The `Dockerfile` creates `/usr/local/bin/run-medley` which really just execs the real `run-medley`.  But it's missing a path component so it would try to run `.../interlisp/run-medley` say rather than `.../interlisp/medley/run-medley`.

This created file is not in fact used in the Docker image, so perhaps it should not even be created.  But if it is created it should probably be right.