### PR TITLE
add a '-timestamp' option to run-medley that timestamps lisp.virtualmem

### DIFF
--- a/run-medley
+++ b/run-medley
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -x
 #               Run Medley
 #
 # Syntax: run-medley [-noscroll]                 #turn off scrollbars
@@ -114,16 +114,32 @@ while [ "$#" -ne 0 ]; do
 	    mem="-m $2 "
 	    shift
 	    ;;
+
         "-vmem" | "--vmem" | "-vmfile" )
             export LDEDESTSYSOUT="$2"
             shift
             ;;
+
+	"-timestamp" )
+	    savedvm="$LDEDESTSYSOUT."`date +%y%m%d%H%M%S`
+	    if [ -f "$LDEDESTSYSOUT" ]; then    # already a lisp.vmem
+		latest=`ls -t ${LDEDESTSYSOUT}* | head -n 1`
+		echo saved  $savedvm    latest   $latest
+		export LDESRCESYSOUT="$latest"
+		ln "$LDEDESTSYSOUT" "$savedvm"  # link it to the dated
+		export LDESRCESYSOUT="$savedvm" # 
+	    fi 
+	    export LDEDESTSYSOUT="$savedvm" 
+	    ;;
+	
         "-full")
             export LDESRCESYSOUT="$MEDLEYDIR/loadups/full.sysout"
             ;;
+	
         "-lisp")
             export LDESRCESYSOUT="$MEDLEYDIR/loadups/lisp.sysout"
             ;;
+
         "-n" | "-new" | "-newfull" )
             export LDESRCESYSOUT="$MEDLEYDIR/tmp/full.sysout"
             ;;
@@ -144,14 +160,6 @@ while [ "$#" -ne 0 ]; do
     esac
     shift
 done
-
-if [ -z "$LDESRCESYSOUT" ] ; then
-    if [ -f "$LDEDESTSYSOUT" ] ; then
-        export LDESRCESYSOUT="$LDEDESTSYSOUT"
-    else
-        export LDESRCESYSOUT="$MEDLEYDIR/loadups/full.sysout"
-    fi
-fi
 
 if [ -z "$geometry" ] ; then
     # maiko guesses wrong
@@ -194,7 +202,7 @@ if ! command -v "$prog" > /dev/null 2>&1; then
     fi
 fi
 
-echo "running: $prog $noscroll $geometry $screensize $mem $pass $LDESRCESYSOUT"
+echo "running: $prog $noscroll $geometry $screensize $mem $pass ($LDEDESTSYSOUT) $LDESRCESYSOUT"
 echo "greet: $LDEINIT"
 
 export INMEDLEY=1


### PR DESCRIPTION
It seemed like we were discussing overlapping concerns with IDLE, LOGOUT and SAVEVM in a PR that had been merged (#904) and then reverted (#922) to address an issue about shutting down online sessions that had been closed, and a related issue #923 that arises when you are NOT online but instead have open multiple sessions on the same machine and them stepping on each other.
 
* Behavior should be configurable simply (e.g. by IDLE.PROFILE)
* don't clog the user's disk or backups
* Distinguish between abandoning a session when falling asleep or called away, vs. closing the X window
* ONLINEP images  (LOGOUT) saving VM if session is abandoned (current behavior)
* Matching D-machine experience (background SAVEVM) is a plus (running two sessions = borrowing one of the pool Dorados)
 
I think some variant of this (draft) PR to timestamp the saved vmems in the file names, using the most recent if starting up with no other qualification.

