### PR TITLE
Add .gitattributes for binary files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Denote all files that are truly binary and should not be modified.
+*.tedit binary
+*.lcom binary
+*.sketch binary
+*.dfasl binary
+*.TEDIT binary
+*.LCOM binary
+*.SKETCH binary
+*.DFASL binary


### PR DESCRIPTION
Add .gitattributes so *.TEDIT, *.LCOM, *.DFASL, and *.SKETCH are always treated as binary (and the lowercase versions).