### PR TITLE
run-medley has a -NF option in caps used by loadup, means no fork

### DIFF
--- a/run-medley
+++ b/run-medley
@@ -128,8 +128,8 @@ while [ "$#" -ne 0 ]; do
         -nl | -newlisp)
             export LDESRCESYSOUT="$MEDLEYDIR/tmp/lisp.sysout"
             ;;
-	-nf)
-            pass="$pass $1"
+	-NF)
+            pass="$pass $1"   	# for making init, don't fork
             ;;
         -*)
 	    pass="$pass $1 $2"


### PR DESCRIPTION
bug fix -- it was introduced by accident.  loadups will fail without this fix.
