### PR TITLE
copy files already done by loadup-all.sh

### DIFF
--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -165,8 +165,6 @@ jobs:
 
       - name: Build loadups release tar
         run: |
-          cp -p tmp/full.sysout tmp/lisp.sysout tmp/whereis.hash loadups/
-          cp -p tmp/exports.all library/
           cd ..
           tar cfz medley/tmp/${release_tag}-loadups.tgz        \
             medley/loadups/lisp.sysout               \

--- a/scripts/loadup-and-release.sh
+++ b/scripts/loadup-and-release.sh
@@ -8,6 +8,5 @@ if [ ! -x run-medley ] ; then
 fi
 
 ./scripts/loadup-all.sh  &&  \
-./scripts/copy-all.sh &&     \
 ./scripts/release-medley.sh
 


### PR DESCRIPTION
The copy-all.sh and copies were redundant -- now already done by loadup-all.sh

