### PR TITLE
Use -title rather than -t to specify window title

### DIFF
--- a/run-medley
+++ b/run-medley
@@ -197,5 +197,5 @@ echo "greet: $LDEINIT"
 
 export INMEDLEY=1
 
-"$prog" $noscroll $geometry $screensize $mem -t "Medley Interlisp" $pass "$LDESRCESYSOUT"
+"$prog" $noscroll $geometry $screensize $mem -title "Medley Interlisp" $pass "$LDESRCESYSOUT"
 


### PR DESCRIPTION
When when lde is compiled for SDL, without the X11 parsing being engaged the "-t" option is used for setting a timer and the title can only be given with "-title".  Always specify it using "-title" in run-medley script.
