### PR TITLE
Bring over buildLoadup.yml updates from fghalasz/medley clone

### DIFF
--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -199,28 +199,28 @@ jobs:
         env:
           release_tag: ${{ steps.tag.outputs.release_tag }}
 
-     - name: Delete existing release with same tag (if any)
-       uses: cb80/delrel@latest
-       with:
-           tag: ${{ env.release_tag }} 
-       continue-on-error: true
-       env:
-          release_tag: ${{ steps.tag.outputs.release_tag }}
-
-     - name: Push the release
-        uses: ncipollo/release-action@v1
-        with: 
-          allowUpdates: true
-          artifacts:
-            tmp/${{ env.release_tag }}-loadups.tgz,
-            tmp/${{ env.release_tag }}-runtime.tgz
-          tag: ${{ env.release_tag }}
-          draft: false
-          prerelease: false
-          generateReleaseNotes: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Delete existing release with same tag (if any)
+        uses: cb80/delrel@latest
+        with:
+            tag: ${{ env.release_tag }} 
+        continue-on-error: true
         env:
-          release_tag: ${{ steps.tag.outputs.release_tag }}
+           release_tag: ${{ steps.tag.outputs.release_tag }}
+
+       - name: Push the release
+         uses: ncipollo/release-action@v1
+         with: 
+           allowUpdates: true
+           artifacts:
+             tmp/${{ env.release_tag }}-loadups.tgz,
+             tmp/${{ env.release_tag }}-runtime.tgz
+           tag: ${{ env.release_tag }}
+           draft: false
+           prerelease: false
+           generateReleaseNotes: true
+           token: ${{ secrets.GITHUB_TOKEN }}
+         env:
+           release_tag: ${{ steps.tag.outputs.release_tag }}
 
 
 ############################################################

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -135,7 +135,7 @@ jobs:
       # release.  Used to download the correct Maiko release
       - name: Get Maiko Release Information
         id: latest_version
-        uses: abatilo/release-info-action@v1.3.0
+        uses: abatilo/release-info-action@v1.3.2
         with:
           owner: ${{ github.repository_owner }}
           repo: maiko

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -166,19 +166,16 @@ jobs:
       - name: Build loadups release tar
         run: |
           cd ..
-          tar cfz medley/tmp/${release_tag}-loadups.tgz        \
+          tar cfz medley/tmp/${RELEASE_TAG}-loadups.tgz        \
             medley/loadups/lisp.sysout               \
             medley/loadups/full.sysout               \
             medley/loadups/whereis.hash              \
             medley/library/exports.all
-
-        env:
-          release_tag: ${{ steps.tag.outputs.release_tag }}
       
       - name: Build runtime release tar
         run: |
           cd ..
-          tar cfz medley/tmp/${release_tag}-runtime.tgz          \
+          tar cfz medley/tmp/${RELEASE_TAG}-runtime.tgz          \
                      --exclude "*~" --exclude "*#*"              \
                      --exclude exports.all                       \
                      medley/clos                                 \
@@ -196,8 +193,6 @@ jobs:
                      medley/lispusers                            \
                      medley/sources                              \
                      medley/internal
-        env:
-          release_tag: ${{ steps.tag.outputs.release_tag }}
 
       - name: Delete existing release with same tag (if any)
         uses: cb80/delrel@latest

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -199,8 +199,15 @@ jobs:
         env:
           release_tag: ${{ steps.tag.outputs.release_tag }}
 
+     - name: Delete existing release with same tag (if any)
+       uses: cb80/delrel@latest
+       with:
+           tag: ${{ env.release_tag }} 
+       continue-on-error: true
+       env:
+          release_tag: ${{ steps.tag.outputs.release_tag }}
 
-      - name: Push the release
+     - name: Push the release
         uses: ncipollo/release-action@v1
         with: 
           allowUpdates: true

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -200,36 +200,53 @@ jobs:
           release_tag: ${{ steps.tag.outputs.release_tag }}
 
 
-      - name: "Create release"
-        uses: "actions/github-script@v6"
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          script: |
-            try {
-              await github.rest.repos.createRelease({
-                draft: false,
-                generate_release_notes: true,
-                name: process.env.release_tag,
-                owner: context.repo.owner,
-                prerelease: false,
-                repo: context.repo.repo,
-                tag_name: process.env.release_tag,
-              });
-            } catch (error) {
-              core.setFailed(error.message);
-            }
+      - name: Push the release
+        uses: ncipollo/release-action@v1
+        with: 
+          allowUpdates: true
+          artifacts:
+            tmp/${{ env.release_tag }}-loadups.tgz,
+            tmp/${{ env.release_tag }}-runtime.tgz
+          tag: ${{ env.release_tag }}
+          draft: false
+          prerelease: false
+          generateReleaseNotes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
         env:
           release_tag: ${{ steps.tag.outputs.release_tag }}
 
-      - name: "Upload release assets"
-        uses: AButler/upload-release-assets@v2.0.2
-        with:
-          files: 'tmp/${{ env.release_tag }}-loadups.tgz;tmp/${{ env.release_tag }}-runtime.tgz'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          release-tag: ${{ env.release_tag }}
-        env:
-          release_tag: ${{ steps.tag.outputs.release_tag }}
 
+############################################################
+#      - name: "Create release"
+#        uses: "actions/github-script@v6"
+#        with:
+#          github-token: "${{ secrets.GITHUB_TOKEN }}"
+#          script: |
+#            try {
+#              await github.rest.repos.createRelease({
+#                draft: false,
+#                generate_release_notes: true,
+#                name: process.env.release_tag,
+#                owner: context.repo.owner,
+#                prerelease: false,
+#                repo: context.repo.repo,
+#                tag_name: process.env.release_tag,
+#              });
+#            } catch (error) {
+#              core.setFailed(error.message);
+#            }
+#        env:
+#          release_tag: ${{ steps.tag.outputs.release_tag }}
+#
+#      - name: "Upload release assets"
+#        uses: AButler/upload-release-assets@v2.0.2
+#        with:
+#          files: 'tmp/${{ env.release_tag }}-loadups.tgz;tmp/${{ env.release_tag }}-runtime.tgz'
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#          release-tag: ${{ env.release_tag }}
+#        env:
+#          release_tag: ${{ steps.tag.outputs.release_tag }}
+#################################################################
 
 ######################################################################################
 

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -207,20 +207,20 @@ jobs:
         env:
            release_tag: ${{ steps.tag.outputs.release_tag }}
 
-       - name: Push the release
-         uses: ncipollo/release-action@v1
-         with: 
-           allowUpdates: true
-           artifacts:
-             tmp/${{ env.release_tag }}-loadups.tgz,
-             tmp/${{ env.release_tag }}-runtime.tgz
-           tag: ${{ env.release_tag }}
-           draft: false
-           prerelease: false
-           generateReleaseNotes: true
-           token: ${{ secrets.GITHUB_TOKEN }}
-         env:
-           release_tag: ${{ steps.tag.outputs.release_tag }}
+      - name: Push the release
+        uses: ncipollo/release-action@v1
+        with: 
+          allowUpdates: true
+          artifacts:
+            tmp/${{ env.release_tag }}-loadups.tgz,
+            tmp/${{ env.release_tag }}-runtime.tgz
+          tag: ${{ env.release_tag }}
+          draft: false
+          prerelease: false
+          generateReleaseNotes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          release_tag: ${{ steps.tag.outputs.release_tag }}
 
 
 ############################################################

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -197,58 +197,21 @@ jobs:
       - name: Delete existing release with same tag (if any)
         uses: cb80/delrel@latest
         with:
-            tag: ${{ env.release_tag }} 
+            tag: ${{ env.RELEASE_TAG }} 
         continue-on-error: true
-        env:
-           release_tag: ${{ steps.tag.outputs.release_tag }}
 
       - name: Push the release
         uses: ncipollo/release-action@v1
         with: 
           allowUpdates: true
           artifacts:
-            tmp/${{ env.release_tag }}-loadups.tgz,
-            tmp/${{ env.release_tag }}-runtime.tgz
-          tag: ${{ env.release_tag }}
+            tmp/${{ env.RELEASE_TAG }}-loadups.tgz,
+            tmp/${{ env.RELEASE_TAG }}-runtime.tgz
+          tag: ${{ env.RELEASE_TAG }}
           draft: false
           prerelease: false
           generateReleaseNotes: true
           token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          release_tag: ${{ steps.tag.outputs.release_tag }}
-
-
-############################################################
-#      - name: "Create release"
-#        uses: "actions/github-script@v6"
-#        with:
-#          github-token: "${{ secrets.GITHUB_TOKEN }}"
-#          script: |
-#            try {
-#              await github.rest.repos.createRelease({
-#                draft: false,
-#                generate_release_notes: true,
-#                name: process.env.release_tag,
-#                owner: context.repo.owner,
-#                prerelease: false,
-#                repo: context.repo.repo,
-#                tag_name: process.env.release_tag,
-#              });
-#            } catch (error) {
-#              core.setFailed(error.message);
-#            }
-#        env:
-#          release_tag: ${{ steps.tag.outputs.release_tag }}
-#
-#      - name: "Upload release assets"
-#        uses: AButler/upload-release-assets@v2.0.2
-#        with:
-#          files: 'tmp/${{ env.release_tag }}-loadups.tgz;tmp/${{ env.release_tag }}-runtime.tgz'
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
-#          release-tag: ${{ env.release_tag }}
-#        env:
-#          release_tag: ${{ steps.tag.outputs.release_tag }}
-#################################################################
 
 ######################################################################################
 


### PR DESCRIPTION
Updates to buildLoadup.yml to take care of deprecated features in github actions:  1) elimination of ::set-output:: feature in steps and 2) deprecation of Node 12 in favor of Node 16 as runner for GH Actions.  This mostly involved updating versions of various marketplace actions.
