### PR TITLE
Allow user override of -title option

### DIFF
--- a/run-medley
+++ b/run-medley
@@ -41,6 +41,7 @@ pass=""
 mem="-m 256"
 scroll=22
 noscroll=""
+title="Medley Interlisp"
 
 if [ -z "$LDEDESTSYSOUT" ] ; then
     if [ -z "$LOGINDIR" ] ; then
@@ -110,6 +111,10 @@ while [ "$#" -ne 0 ]; do
 	    ;;
 	-m | -mem)
 	    mem="-m $2 "
+	    shift
+	    ;;
+	-title)
+	    title="$2"
 	    shift
 	    ;;
         -vmem | --vmem | -vmfile)
@@ -192,10 +197,10 @@ if ! command -v "$prog" > /dev/null 2>&1; then
     fi
 fi
 
-echo "running: $prog $noscroll $geometry $screensize $mem $pass $LDESRCESYSOUT"
+echo "running: $prog $noscroll $geometry $screensize -title \"$title\" $mem $pass $LDESRCESYSOUT"
 echo "greet: $LDEINIT"
 
 export INMEDLEY=1
 
-"$prog" $noscroll $geometry $screensize $mem -title "Medley Interlisp" $pass "$LDESRCESYSOUT"
+"$prog" $noscroll $geometry $screensize $mem -title "$title" $pass "$LDESRCESYSOUT"
 


### PR DESCRIPTION
The switch from `-t` to `-title` to specify the default title had the unintended side-effect of preventing a user override of `-t` by `-title`.  Only set the default title (Medley Interlisp) if there is none specified on the command line.