### PR TITLE
Pass --display/-d argument as -display not by setting DISPLAY env variable

### DIFF
--- a/run-medley
+++ b/run-medley
@@ -41,6 +41,7 @@ pass=""
 mem="-m 256"
 scroll=22
 noscroll=""
+display=""
 title="Medley Interlisp"
 
 if [ -z "$LDEDESTSYSOUT" ] ; then
@@ -100,7 +101,7 @@ while [ "$#" -ne 0 ]; do
             shift
             ;;
         --display | -d)
-            export DISPLAY="$2"
+	    display="-display $2"
             shift
             ;;
 	-prog)
@@ -195,10 +196,10 @@ if ! command -v "$prog" > /dev/null 2>&1; then
     fi
 fi
 
-echo "running: $prog $noscroll $geometry $screensize -title \"$title\" $mem $pass $LDESRCESYSOUT"
+echo "running: $prog $display $noscroll $geometry $screensize -title \"$title\" $mem $pass $LDESRCESYSOUT"
 echo "greet: $LDEINIT"
 
 export INMEDLEY=1
 
-"$prog" $noscroll $geometry $screensize $mem -title "$title" $pass "$LDESRCESYSOUT"
+"$prog" $display $noscroll $geometry $screensize $mem -title "$title" $pass "$LDESRCESYSOUT"
 


### PR DESCRIPTION
The way it was originally coded, `-display foo` would get passed as-is (in the passthrough arguments) but `-d` and `--display` would get transformed into setting the `DISPLAY` environment variable to `foo`.  Let's not promote confusion by having them work differently, and not prevent the user from setting `DISPLAY` (outside run-medley) when they want to use `-d` or `--display`.