### PR TITLE
Add ipfonts to release tars

### DIFF
--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -56,8 +56,8 @@ on:
 defaults:
   run:
     shell: bash
-    
-  
+
+
 jobs:
 
 ######################################################################################
@@ -83,7 +83,7 @@ jobs:
               echo "draft=${{ inputs.draft }}" >> $GITHUB_OUTPUT;
               echo "force=${{ inputs.force }}" >> $GITHUB_OUTPUT;
           fi
-        
+
 
 
 ######################################################################################
@@ -97,7 +97,7 @@ jobs:
     outputs:
       release_not_built: ${{ steps.check.outputs.release_not_built }}
 
-    steps: 
+    steps:
       # Checkout the actions for this repo owner
       - name: Checkout Actions
         uses: actions/checkout@v3
@@ -107,7 +107,7 @@ jobs:
       - run: mv ./Actions_${{ github.sha }}/actions ../actions && rm -rf ./Actions_${{ github.sha }}
 
       # Check if build already run for this commit
-      - name: Build already completed? 
+      - name: Build already completed?
         id: check
         continue-on-error: true
         uses: ./../actions/check-sentry-action
@@ -135,7 +135,7 @@ jobs:
     if: |
       needs.sentry.outputs.release_not_built == 'true'
       || needs.inputs.outputs.force == 'true'
-    
+
     steps:
       # Checkout the actions for this repo owner
       - name: Checkout Actions
@@ -162,7 +162,7 @@ jobs:
         with:
           owner: ${{ github.repository_owner }}
           repo: maiko
-          
+
       # Setup environment variables & establish job outputs
       - name: Setup Environment Variables
         run: |
@@ -198,7 +198,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: true
           out-file-path: ${{ env.TARBALL_DIR }}
-          fileName: "${{ env.MAIKO_RELEASE_TAG }}-linux.*.tgz" 
+          fileName: "${{ env.MAIKO_RELEASE_TAG }}-linux.*.tgz"
 
       - name: Untar Maiko Release for use in loadup
         run: |
@@ -224,9 +224,9 @@ jobs:
         run: |
           Xvnc -geometry 1280x720 :0 &
           export DISPLAY=":0"
-          PATH="$PWD/maiko:$PATH" 
+          PATH="$PWD/maiko:$PATH"
           scripts/loadup-all.sh -apps
-      
+
       - name: Build loadups release tar
         run: |
           cd ..
@@ -237,7 +237,7 @@ jobs:
             medley/loadups/apps.sysout               \
             medley/loadups/whereis.hash              \
             medley/library/exports.all
-      
+
       - name: Build runtime release tar
         run: |
           cd ..
@@ -258,6 +258,7 @@ jobs:
                      medley/fonts/altofonts                      \
                      medley/fonts/adobe                          \
                      medley/fonts/postscriptfonts                \
+                     medley/fonts/ipfonts                        \
                      medley/library                              \
                      medley/lispusers                            \
                      medley/sources                              \
@@ -277,13 +278,13 @@ jobs:
       - name: Delete existing release with same tag (if any)
         uses: cb80/delrel@latest
         with:
-            tag: ${{ env.MEDLEY_RELEASE_TAG }} 
+            tag: ${{ env.MEDLEY_RELEASE_TAG }}
         continue-on-error: true
 
       - name: Push the release
         id: push_release
         uses: ncipollo/release-action@v1
-        with: 
+        with:
           allowUpdates: true
           artifacts:
             ${{ env.TARBALL_DIR }}/${{ env.MEDLEY_RELEASE_TAG }}-loadups.tgz,
@@ -335,7 +336,7 @@ jobs:
           $url = "https://sourceforge.net/projects/tigervnc/files/stable/1.12.0/vncviewer64-1.12.0.exe"
           $output = "installers\win\vncviewer64-1.12.0.exe"
           (New-Object System.Net.WebClient).DownloadFile($url, $output)
- 
+
       # Run iscc.exe to compile the installer
       - name: Compile medley.iss
         shell: powershell
@@ -348,7 +349,7 @@ jobs:
       - name: Upload windows installer to release
         id: push
         uses: ncipollo/release-action@v1
-        with: 
+        with:
           allowUpdates: true
           artifacts: installers/win/${{ env.INSTALLER_FILENAME }}
           tag: ${{ env.MEDLEY_RELEASE_TAG }}
@@ -381,7 +382,7 @@ jobs:
             else
                 remote_filename="${local_filename%.html}"
                 remote_manname="man_medley.html"
-            fi            
+            fi
             remote_filepath="/srv/oio/static/${remote_filename}"
             remote_manpath="/srv/oio/static/${remote_manname}"
             # Fill in downloads page template
@@ -403,7 +404,7 @@ jobs:
             sftp -o StrictHostKeyChecking=no -b batch ubuntu@online.interlisp.org
         env:
             SSH_KEY: ${{ secrets.OIO_SSH_KEY }}
-      
+
 
 
 ######################################################################################
@@ -420,7 +421,7 @@ jobs:
 
     needs: [inputs, sentry, loadup, windows_installer]
 
-    steps: 
+    steps:
       # Checkout the actions for this repo owner
       - name: Checkout Actions
         uses: actions/checkout@v3
@@ -440,7 +441,7 @@ jobs:
         id: output
         run: |
           echo "build_successful='true'" >> $GITHUB_OUTPUT
-          
+
 ######################################################################################
 
 


### PR DESCRIPTION
As per @rmkaplan's request, this PR adds fonts/ipfonts to the release tars (and installers).

Note, however, this PR does not affect the loadups - so the ipfonts are not loaded into full.sysout as are the postscriptfonts.  See LOADUPFULLFONTS in sources/LOADUP-FULL. 

-- Frank