### PR TITLE
release dribbles and msfuller

### DIFF
--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -236,6 +236,8 @@ jobs:
             medley/loadups/full.sysout               \
             medley/loadups/apps.sysout               \
             medley/loadups/whereis.hash              \
+	    medley/loadups/*.dribble                 \
+	    medley/loadups/fuller.database           \
             medley/loadups/exports.all
 
       - name: Build runtime release tar

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ loadups/full.sysout
 loadups/*.dribble
 loadups/whereis.hash
 loadups/apps.sysout
+loadups/fuller.database
 
 # manual cross-reference files
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ tmp/*
 
 # all loadup files 
 
-library/exports.all
+loadups/exports.all
 library/RDSYS*
 loadups/lisp.sysout
 loadups/full.sysout

--- a/scripts/copy-all.sh
+++ b/scripts/copy-all.sh
@@ -12,6 +12,14 @@ fi
 # cp -p tmp/exports.all tmp/RDSYS tmp/RDSYS.LCOM library/
 # just copy the files that are released
 
+./scripts/cpv tmp/init.dribble loadups
+./scripts/cpv tmp/lisp.dribble loadups
+./scripts/cpv tmp/full.dribble loadups
+./scripts/cpv tmp/fuller.dribble loadups
+./scripts/cpv tmp/whereis.dribble loadups
+
+./scripts/cpv tmp/fuller.database loadups
+
 ./scripts/cpv tmp/full.sysout loadups
 ./scripts/cpv tmp/lisp.sysout loadups
 ./scripts/cpv tmp/whereis.hash loadups

--- a/scripts/release-medley.sh
+++ b/scripts/release-medley.sh
@@ -19,14 +19,15 @@ echo making $tag-loadups.tgz
 tar cfz medley/tmp/$tag-loadups.tgz                       \
     medley/loadups/lisp.sysout                            \
     medley/loadups/full.sysout                            \
+    medley/loadups/fuller.database                        \
+    medley/loadups/*.dribble                              \
     medley/loadups/whereis.hash                           \
-    medley/library/exports.all
+    medley/loadups//exports.all
 	
 echo making $tag-runtime.tgz
 
 tar cfz medley/tmp/$tag-runtime.tgz                       \
     --exclude "*~" --exclude "*#*"                        \
-    --exclude exports.all                                 \
     medley/docs/dinfo                                     \
     medley/doctools                                       \
     medley/greetfiles                                     \


### PR DESCRIPTION
- ignore loadups/exports.all (moved)
- add fuller.database and dribble files to release
