### PR TITLE
Moving vncviewer to online.interlisp.org/downloads to bypass issues with sourceforge in buildLoadup.yml

### DIFF
--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -301,7 +301,7 @@ jobs:
       - name: Download vncviewer
         shell: powershell
         run: |
-          $url = "https://sourceforge.net/projects/tigervnc/files/stable/1.12.0/vncviewer64-1.12.0.exe"
+          $url = "https://online.interlisp.org/downloads/vncviewer64-1.12.0.exe"
           $output = "installers\win\vncviewer64-1.12.0.exe"
           (New-Object System.Net.WebClient).DownloadFile($url, $output)
 


### PR DESCRIPTION
This fixes problems that has been holding up automated builds since mid-July.
