### PR TITLE
Fix Issue#1323: buildDocker.yml Github Action is failing due to Ubuntu 22.10 being deprecated

### DIFF
--- a/.github/workflows/Dockerfile_medley
+++ b/.github/workflows/Dockerfile_medley
@@ -31,6 +31,11 @@ ENV LANG=C.UTF-8
 # Copy over the release deb files
 ADD ./*.deb /tmp
 
+# Get tzdata setup ahead of time
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata; \
+    dpkg-reconfigure --frontend noninteractive tzdata
+
 # Install Medley/Maiko and add tightvnc server and xclip to the image
 RUN apt-get update                                               \
     && apt-get install -y apt-utils                              \ 

--- a/.github/workflows/Dockerfile_medley
+++ b/.github/workflows/Dockerfile_medley
@@ -7,7 +7,7 @@
 #
 # ******************************************************************************
 
-FROM ubuntu:22.10
+FROM ubuntu:20.04
 ARG TARGETPLATFORM
 
 #  Handle ARGs, ENV variables, and LABELs

--- a/.github/workflows/Dockerfile_medley
+++ b/.github/workflows/Dockerfile_medley
@@ -32,7 +32,8 @@ ENV LANG=C.UTF-8
 ADD ./*.deb /tmp
 
 # Get tzdata setup ahead of time
-RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime; \
+RUN apt-get update; \
+    ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata; \
     dpkg-reconfigure --frontend noninteractive tzdata
 

--- a/.github/workflows/Dockerfile_medley
+++ b/.github/workflows/Dockerfile_medley
@@ -7,7 +7,7 @@
 #
 # ******************************************************************************
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG TARGETPLATFORM
 
 #  Handle ARGs, ENV variables, and LABELs

--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -20,7 +20,7 @@ name: 'Build/Push Docker Image'
 # Run this workflow on ...
 on:
   workflow_dispatch:
-    inputs: 
+    inputs:
       draft:
         description: "Mark this as a draft release"
         type: choice
@@ -33,7 +33,7 @@ on:
         options:
         - 'false'
         - 'true'
-  
+
   workflow_call:
     outputs:
       successful:
@@ -59,7 +59,7 @@ on:
 defaults:
   run:
     shell: bash
-    
+
 
 jobs:
 
@@ -86,7 +86,7 @@ jobs:
               echo "draft=${{ inputs.draft }}" >> $GITHUB_OUTPUT;
               echo "force=${{ inputs.force }}" >> $GITHUB_OUTPUT;
           fi
-        
+
 
 
 ######################################################################################
@@ -100,7 +100,7 @@ jobs:
     outputs:
       release_not_built: ${{ steps.check.outputs.release_not_built }}
 
-    steps: 
+    steps:
       # Checkout the actions for this repo owner
       - name: Checkout Actions
         uses: actions/checkout@v3
@@ -110,7 +110,7 @@ jobs:
       - run: mv ./Actions_${{ github.sha }}/actions ../actions && rm -rf ./Actions_${{ github.sha }}
 
       # Check if build already run for this commit
-      - name: Build already completed? 
+      - name: Build already completed?
         id: check
         continue-on-error: true
         uses: ./../actions/check-sentry-action
@@ -131,12 +131,12 @@ jobs:
     if: |
       needs.sentry.outputs.release_not_built == 'true'
       || needs.inputs.outputs.force == 'true'
-    
+
     steps:
       # Checkout latest commit
       - name: Checkout Medley
         uses: actions/checkout@v3
-  
+
       # Find latest release (draft or normal)
       # and download its assets
       - name: Download linux debs from latest (draft) release
@@ -176,10 +176,10 @@ jobs:
           docker_namespace="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
           docker_image="${docker_namespace}/${repo_name}"
           if [ "${{ needs.inputs.outputs.draft }}" = "false" ];
-          then 
+          then
               docker_tags="${docker_image}:latest,${docker_image}:${MEDLEY_RELEASE#*-}_${MAIKO_RELEASE#*-}"
               platforms="linux/amd64,linux/arm64"
-          else 
+          else
               docker_tags="${docker_image}:draft"
               platforms="linux/amd64"
           fi
@@ -242,7 +242,7 @@ jobs:
 
     needs: [inputs, sentry, build_and-push]
 
-    steps: 
+    steps:
       # Checkout the actions for this repo owner
       - name: Checkout Actions
         uses: actions/checkout@v3
@@ -257,10 +257,10 @@ jobs:
         uses: ./../actions/set-sentry-action
         with:
           tag: "docker"
-     
+
       - name: Output
         id: output
         run: |
           echo "build_successful='true'" >> ${GITHUB_OUTPUT}
-          
+
 ######################################################################################


### PR DESCRIPTION
This PR moves the docker build back to Ubuntu 22.04, which is an LTS release.

Also "fixes" an issue with how TZDATA package was loaded into Ubuntu.  Not sure that it was absolutely necessary to do this.  But it works, so ...

Finally, fixed a slew of trailing whitespace issues for buildDocker.yml.  A completely cosmetic change that makes it easier to edit in editors that see trailing whitespace as an error.