### PR TITLE
Modify launcher to enable --title STRING option to work when STRING has embedded spaces (multiple words).

### DIFF
--- a/run-medley
+++ b/run-medley
@@ -113,7 +113,9 @@ while [ "$#" -ne 0 ]; do
 	    shift
 	    ;;
 	-title)
-	    title="$2"
+        if [ -n "$2" ] ; then
+	        title="$2"
+        fi
 	    shift
 	    ;;
         -vmem | --vmem | -vmfile)

--- a/scripts/medley/medley.command
+++ b/scripts/medley/medley.command
@@ -139,7 +139,7 @@ mkdir -p ${LOGINDIR}/vmem
 if [[ ( ${darwin} = true ) || (( ${wsl} = false || ${use_vnc} = false ) && ${docker} = false) ]];
 then
   # If not using vnc, just call run-medley
-  ${MEDLEYDIR}/run-medley -id "${run_id}" ${geometry} ${screensize} ${run_args[@]}
+  ${MEDLEYDIR}/run-medley -id "${run_id}" -title "${title}" ${geometry} ${screensize} ${run_args[@]}
 else
   # do the vnc thing on wsl or docker
   source ${SCRIPTDIR}/medley_vnc.sh

--- a/scripts/medley/medley_args.sh
+++ b/scripts/medley/medley_args.sh
@@ -28,6 +28,7 @@ run_id="default"
 screensize=""
 sysout_flag=false
 sysout_arg=""
+title=""
 use_vnc=false
 windows=false
 
@@ -112,7 +113,8 @@ do
         ;;
       -t | --title)
         check_for_dash_or_end "$1" "$2"
-        run_args+=(-title $2)
+        #run_args+=(-title $2)
+        title="$2"
         shift
         ;;
       -v | --vnc)


### PR DESCRIPTION
(Obviously, this is extremely low priority, but it was a little annoying that it didn't work.)