### PR TITLE
Extend changes made in PR#1356 to handle vnc case and well as without vnc case.

### DIFF
--- a/scripts/medley/medley_args.sh
+++ b/scripts/medley/medley_args.sh
@@ -28,7 +28,7 @@ run_id="default"
 screensize=""
 sysout_flag=false
 sysout_arg=""
-title=""
+title="Medley Interlisp"
 use_vnc=false
 windows=false
 
@@ -113,8 +113,7 @@ do
         ;;
       -t | --title)
         check_for_dash_or_end "$1" "$2"
-        #run_args+=(-title $2)
-        title="$2"
+        if [ -n "$2" ]; then title="$2"; fi
         shift
         ;;
       -v | --vnc)

--- a/scripts/medley/medley_vnc.sh
+++ b/scripts/medley/medley_vnc.sh
@@ -164,6 +164,7 @@
                 -SecurityTypes None \
                 -NeverShared \
                 -DisconnectClients=0 \
+                -desktop "${title}" \
                 --MaxDisconnectionTime=10 \
                 >> ${LOG} 2>&1 &
 


### PR DESCRIPTION
PR#1356 (by @MattHeffron) fixed medley.sh (et al) to handle --title argument with spaces.  But changes only worked in cases where the --vnc option was not set.  This PR extends Matt's changes to apply to the case where --vnc is set.
