### PR TITLE
Add copy-full.sh to loadup-full.sh script to copy loadup products into MEDLEYDIR/loadups

### DIFF
--- a/scripts/copy-full.sh
+++ b/scripts/copy-full.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+if [ ! -x run-medley ] ; then
+    echo run from MEDLEYDIR
+    exit 1
+fi
+
+. scripts/loadup-setup.sh
+
+echo ">>>>> START ${script_name}"
+
+./scripts/cpv "${LOADUP_WORKDIR}"/full.sysout "${LOADUP_OUTDIR}"  | sed -e "s#${MEDLEYDIR}/##g"
+./scripts/cpv "${LOADUP_WORKDIR}"/lisp.sysout "${LOADUP_OUTDIR}"  | sed -e "s#${MEDLEYDIR}/##g"
+
+./scripts/cpv "${LOADUP_WORKDIR}"/init.dribble "${LOADUP_OUTDIR}" | sed -e "s#${MEDLEYDIR}/##g"
+./scripts/cpv "${LOADUP_WORKDIR}"/lisp.dribble "${LOADUP_OUTDIR}" | sed -e "s#${MEDLEYDIR}/##g"
+./scripts/cpv "${LOADUP_WORKDIR}"/full.dribble "${LOADUP_OUTDIR}" | sed -e "s#${MEDLEYDIR}/##g"
+
+./scripts/cpv "${LOADUP_WORKDIR}"/RDSYS library | sed -e "s#${MEDLEYDIR}/##g"
+./scripts/cpv "${LOADUP_WORKDIR}"/RDSYS.LCOM library | sed -e "s#${MEDLEYDIR}/##g"
+
+echo "<<<<< END ${script_name}"
+echo ""
+exit 0

--- a/scripts/loadup-full.sh
+++ b/scripts/loadup-full.sh
@@ -10,5 +10,14 @@ fi
 ./scripts/loadup-init.sh && \
 ./scripts/loadup-mid-from-init.sh && \
 ./scripts/loadup-lisp-from-mid.sh && \
-./scripts/loadup-full-from-lisp.sh
+./scripts/loadup-full-from-lisp.sh && \
+./scripts/copy-full.sh
+
+if [ $? -eq 0 ];
+then
+  echo "+++++ loadup-full.sh: SUCCESS +++++"
+else
+  echo "----- loadup-full.sh: FAILURE -----"
+fi
+
 


### PR DESCRIPTION
As per request from @rmkaplan: Make loadup-full.sh akin to loadup-all.sh in that it copies its products from the tmp directory into MEDLEYDIR/loadups.