### PR TITLE
Fix loadup-apps-from-full.sh so that it fails gracefully when a notecards directory cannot be found

### DIFF
--- a/scripts/loadup-apps-from-full.sh
+++ b/scripts/loadup-apps-from-full.sh
@@ -23,6 +23,14 @@ if [ ! -e ${NOTECARDSDIR} ]; then
     fi
 fi
 
+if [ -z "${NOTECARDSDIR}" ]; then
+    echo "Error: Cannot find the Notecards directory"
+    echo "It should be located at ${MEDLEYDIR}/../notecards or"
+    echo "${MEDLEYDIR}/../../notecards.  But its not."
+    echo "Exiting"
+    exit 1
+fi
+
 cat >"${cmfile}" <<"EOF"
 "
 


### PR DESCRIPTION
Previously  loadup-apps-from-full.sh failed in a mysterious way when the Notecards directory cannot be found.  Now fails with a clear error message and an exit 1.