### PR TITLE
Fix for Issue #1472 (loadup failure on btrfs):  update how cpv scripts handles hardlink versus copy

### DIFF
--- a/scripts/cpv
+++ b/scripts/cpv
@@ -65,7 +65,14 @@ fi
 
 # make new version and link it
 
-$(ln_or_cp $file $dest.~new~) $file $dest.~$new~
+#$(ln_or_cp $file $dest.~new~) $file $dest.~$new~
+ln $file $dest.~$new~ >/dev/null 2>&1
+if [ $? -ne 0 ]
+then
+    echo "Copying"
+    cp -p $file $dest.~$new~
+fi
+
 echo "Added $(basename $dest.~$new~) to $(dirname $dest.~$new~)"
 rm -f $dest
 ln $dest.~$new~ $dest

--- a/scripts/cpv
+++ b/scripts/cpv
@@ -3,13 +3,6 @@
 # cpv file dest
 # could extend with -r or copying multiple files
 
-ln_or_cp () {
-    f=$(df $(dirname $1) | tail -1 | awk '{ print $1 }')
-    d=$(df $(dirname $2) | tail -1 | awk '{ print $1 }')
-    if [ "$f" != "$d" ]; then cmd="cp -p"; else cmd="ln"; fi
-    echo $cmd
-}
-
 file="$1"
 dest="$2"
 
@@ -64,12 +57,9 @@ else
 fi
 
 # make new version and link it
-
-#$(ln_or_cp $file $dest.~new~) $file $dest.~$new~
 ln $file $dest.~$new~ >/dev/null 2>&1
 if [ $? -ne 0 ]
 then
-    echo "Copying"
     cp -p $file $dest.~$new~
 fi
 


### PR DESCRIPTION
Previously cpv used df to pre-determine whether a hardlink will succeed (and if it pre-determined the hardlink would not succeed, it used cp instead of ln).  This pre-determination strategy failed a  btrfs filesystem (with subvolumes) because df treated the btrfs as a single filesystem (and hence ln should succeed) even though its subvolumes had separate inode spaces.

Updated cpv to use the strategy of just trying the ln.  If it succeeds all well and good.  If it fails, then use a cp.  No need to do any buggy pre-determining (guessing?) if ln will succeed or fail.

