### PR TITLE
Update documentation link from Wiki to project site

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
-See [Documentation links](https://github.com/Interlisp/medley/wiki/Documentation)
-a complete list of available documentation. Much of the documentation still
+See [Using Medley](https://interlisp.org/software/using-medley)
+for a list of available documentation. Much of the documentation still
 needs review and updating.
 
 This directory has source (.TEDIT) for some documents that are found elsewhere.


### PR DESCRIPTION
The README file of the `docs` directory links to the out of date [Wiki documentation page](https://github.com/Interlisp/medley/wiki/Documentation). This patch replaces that link with a link to the [Using Medley](https://interlisp.org/software/using-medley) page of the project site, which provides the same information and is maintained.
