### PR TITLE
Fix issue with release workflow whereby not pushing docker image to docker hub / update versions on all actions 

### DIFF
--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -63,31 +63,6 @@ defaults:
 
 jobs:
 
-######################################################################################
-
-  # Regularize the inputs so they can be referenced the same way whether they are
-  # the result of a workflow_dispatch or a workflow_call
-
-  inputs:
-    runs-on: ubuntu-latest
-    outputs:
-      draft: ${{ steps.one.outputs.draft }}
-      force: ${{ steps.one.outputs.force }}
-    steps:
-      - id: one
-        run: >
-          if [ '${{ toJSON(inputs) }}' = 'null'  ];
-          then
-              echo "workflow_dispatch";
-              echo "draft=${{ github.event.inputs.draft }}" >> $GITHUB_OUTPUT;
-              echo "force=${{ github.event.inputs.force }}" >> $GITHUB_OUTPUT;
-          else
-              echo "workflow_call";
-              echo "draft=${{ inputs.draft }}" >> $GITHUB_OUTPUT;
-              echo "force=${{ inputs.force }}" >> $GITHUB_OUTPUT;
-          fi
-
-
 
 ######################################################################################
 
@@ -95,7 +70,6 @@ jobs:
   # based on the latest commit to the repo
 
   sentry:
-    needs: inputs
     runs-on: ubuntu-latest
     outputs:
       release_not_built: ${{ steps.check.outputs.release_not_built }}
@@ -103,7 +77,7 @@ jobs:
     steps:
       # Checkout the actions for this repo owner
       - name: Checkout Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}
@@ -127,22 +101,22 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    needs: [inputs, sentry]
+    needs: [sentry]
     if: |
       needs.sentry.outputs.release_not_built == 'true'
-      || needs.inputs.outputs.force == 'true'
+      || inputs.force == 'true'
 
     steps:
       # Checkout latest commit
       - name: Checkout Medley
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Find latest release (draft or normal)
       # and download its assets
       - name: Download linux debs from latest (draft) release
         run: |
           tag=""
-          if [ "${{ needs.inputs.outputs.draft }}" = "true" ];
+          if [ "${{ inputs.draft }}" = "true" ];
           then
             tag=$(gh release list | grep Draft | head -n 1 | awk '{ print $3 }')
           fi
@@ -177,7 +151,7 @@ jobs:
           repo_name="${GITHUB_REPOSITORY#*/}"
           docker_namespace="$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
           docker_image="${docker_namespace}/${repo_name}"
-          if [ "${{ needs.inputs.outputs.draft }}" = "false" ];
+          if [ "${{ inputs.draft }}" = "false" ];
           then
               docker_tags="${docker_image}:latest,${docker_image}:${MEDLEY_RELEASE#*-}_${MAIKO_RELEASE#*-}"
               platforms="linux/amd64,linux/arm64"
@@ -195,18 +169,18 @@ jobs:
 
       # Setup the Docker Machine Emulation environment.  
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
 
       # Setup the Docker Buildx funtion
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v3
 
       # Login into DockerHub - required to store the created image
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -215,7 +189,7 @@ jobs:
       # checked out and the release tars just downloaded.
       # Push the result to Docker Hub
       - name: Build Docker Image for Push to Docker Hub
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |
@@ -242,12 +216,12 @@ jobs:
     outputs:
       build_successful: ${{ steps.output.outputs.build_successful }}
 
-    needs: [inputs, sentry, build_and-push]
+    needs: [sentry, build_and-push]
 
     steps:
       # Checkout the actions for this repo owner
       - name: Checkout Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -60,38 +60,12 @@ defaults:
 
 jobs:
 
-# JOB: inputs #######################################################################
-
-  # Regularize the inputs so they can be referenced the same way whether they are
-  # the result of a workflow_dispatch or a workflow_call
-
-  inputs:
-    runs-on: ubuntu-latest
-    outputs:
-      draft: ${{ steps.one.outputs.draft }}
-      force: ${{ steps.one.outputs.force }}
-    steps:
-      - id: one
-        run: >
-          if [ '${{ toJSON(inputs) }}' = 'null'  ];
-          then
-              echo "workflow_dispatch";
-              echo "draft=${{ github.event.inputs.draft }}" >> $GITHUB_OUTPUT;
-              echo "force=${{ github.event.inputs.force }}" >> $GITHUB_OUTPUT;
-          else
-              echo "workflow_call";
-              echo "draft=${{ inputs.draft }}" >> $GITHUB_OUTPUT;
-              echo "force=${{ inputs.force }}" >> $GITHUB_OUTPUT;
-          fi
-
-
 # JOB: sentry #######################################################################
 
   # Use sentry-action to determine if this release has already been built
   # based on the latest commit to the repo
 
   sentry:
-    needs: inputs
     runs-on: ubuntu-latest
     outputs:
       release_not_built: ${{ steps.check.outputs.release_not_built }}
@@ -99,7 +73,7 @@ jobs:
     steps:
       # Checkout the actions for this repo owner
       - name: Checkout Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}
@@ -133,15 +107,15 @@ jobs:
       artifacts_filename_template: ${{ steps.job_outputs.outputs.ARTIFACTS_FILENAME_TEMPLATE }}
       release_url: ${{ steps.push.outputs.html_url }}
 
-    needs: [inputs, sentry]
+    needs: [sentry]
     if: |
       needs.sentry.outputs.release_not_built == 'true'
-      || needs.inputs.outputs.force == 'true'
+      || inputs.force == 'true'
 
     steps:
       # Checkout the actions for this repo owner
       - name: Checkout Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}
@@ -149,7 +123,7 @@ jobs:
 
       # Checkout latest commit
       - name: Checkout Medley
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Setup release tag
       - name: Setup Release Tag
@@ -163,7 +137,7 @@ jobs:
         id: maiko
         run: |
           tag=""
-          if [ "${{ needs.inputs.outputs.draft }}" = "true" ];
+          if [ "${{ inputs.draft }}" = "true" ];
           then
             gh release list --repo ${{ github.repository_owner }}/maiko | grep Draft >/tmp/releases-$$
             if [ $? -eq 0 ];
@@ -219,7 +193,7 @@ jobs:
 
       # Checkout Notecards and tar it in the tarballsdir
       - name: Checkout Notecards
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/notecards
           path: ./notecards
@@ -262,14 +236,14 @@ jobs:
             ${{ env.TARBALL_DIR }}/${{ env.MEDLEY_RELEASE_TAG }}-loadups.tgz,
             ${{ env.TARBALL_DIR }}/${{ env.MEDLEY_RELEASE_TAG }}-runtime.tgz
           tag: ${{ env.MEDLEY_RELEASE_TAG }}
-          draft: ${{ needs.inputs.outputs.draft }}
+          draft: ${{ inputs.draft }}
           prerelease: false
           generateReleaseNotes: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       # Save the tarball directory for subsequent jobs
       - name: Save tarballs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tarballs
           path: ${{ env.TARBALL_DIR }}
@@ -285,16 +259,16 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    needs: [inputs, sentry, loadup]
+    needs: [sentry, loadup]
     if: |
       needs.sentry.outputs.release_not_built == 'true'
-      || needs.inputs.outputs.force == 'true'
+      || inputs.force == 'true'
 
     steps:
 
       # Checkout latest commit
       - name: Checkout Medley
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Environment variables
       - name: Environment variables
@@ -311,7 +285,7 @@ jobs:
 
       #  Get the tarballs
       - name: Get tarballs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tarballs
           path: ${{ env.TARBALL_DIR }}
@@ -345,7 +319,7 @@ jobs:
             mv  medley-full-linux-x86_64-*.tgz medley.tgz
 
       - name: Save medley tar for use in cygwin installers
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: medley-tar
           path: |
@@ -361,10 +335,10 @@ jobs:
 
     runs-on: macos-12
 
-    needs: [inputs, sentry, loadup]
+    needs: [sentry, loadup]
     if: |
       needs.sentry.outputs.release_not_built == 'true'
-      || needs.inputs.outputs.force == 'true'
+      || inputs.force == 'true'
 #    if: false
 
     defaults:
@@ -375,7 +349,7 @@ jobs:
 
       # Checkout latest commit
       - name: Checkout Medley
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Environment variables
       - name: Environment variables
@@ -392,7 +366,7 @@ jobs:
 
       #  Get the tarballs
       - name: Get tarballs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tarballs
           path: ${{ env.TARBALL_DIR }}
@@ -432,10 +406,10 @@ jobs:
 
     runs-on: windows-2022
 
-    needs: [inputs, sentry, loadup, linux_installer]
+    needs: [sentry, loadup, linux_installer]
     if: |
       needs.sentry.outputs.release_not_built == 'true'
-      || needs.inputs.outputs.force == 'true'
+      || inputs.force == 'true'
 
     outputs:
       cygwin_installer: ${{ steps.compile_iss.outputs.CYGWIN_INSTALLER }}
@@ -444,7 +418,7 @@ jobs:
 
       # Checkout latest commit
       - name: Checkout Medley
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Store the values output from loadup job as environment variables
       - name: Environment Variables
@@ -463,7 +437,7 @@ jobs:
 
       # Retrieve medley tars from artifact store
       - name: Retrieve medley tar
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: medley-tar
           path: installers/cygwin/
@@ -535,10 +509,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    needs: [inputs, sentry, loadup, linux_installer, macos_installer, cygwin_installer]
+    needs: [sentry, loadup, linux_installer, macos_installer, cygwin_installer]
     if: |
       needs.sentry.outputs.release_not_built == 'true'
-      || needs.inputs.outputs.force == 'true'
+      || inputs.force == 'true'
 
     steps:
 
@@ -556,7 +530,7 @@ jobs:
 
       # Checkout latest commit
       - name: Checkout Medley
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
 
       # Upload a dummy file to release
@@ -587,7 +561,7 @@ jobs:
             local_template="installers/downloads_page/medley_downloads.html"
             local_filename="medley_downloads.html"
             local_manpath="docs/man-page/man_medley.html"
-            if [ "${{ needs.inputs.outputs.draft }}" = "true" ];
+            if [ "${{ inputs.draft }}" = "true" ];
             then
                 remote_filename="draft_downloads"
                 remote_manname="man_draft.html"
@@ -637,19 +611,19 @@ jobs:
     outputs:
       build_successful: ${{ steps.output.outputs.build_successful }}
 
-    needs: [inputs, sentry, loadup, downloads_page]
+    needs: [sentry, loadup, downloads_page]
 
     steps:
       # Delete the tarballs artifact
       - name: Delete tarballs artifact
-        uses: geekyeggo/delete-artifact@v2
+        uses: geekyeggo/delete-artifact@v5
         with:
           name: tarballs
           failOnError: false
 
       # Checkout the actions for this repo owner
       - name: Checkout Actions
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -75,7 +75,7 @@ jobs:
     steps:
       - id: one
         run: >
-          if [ '${{ toJSON(inputs) }}' != 'null'  ];
+          if [ '${{ toJSON(inputs) }}' != '{}'  ];
           then
             echo "draft=${{ inputs.draft }}" >> $GITHUB_OUTPUT;
             echo "force=${{ inputs.force }}" >> $GITHUB_OUTPUT;

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -20,6 +20,8 @@ name: "Build/Push Release & Docker"
 on:
   schedule:
     - cron: '0 9 * * 1'
+    - cron: '0 9 * * 2'
+    - cron: '0 9 * * 3'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Scheduled kickoff of the buildReleaseInclDocker workflow was not properly storing the Medley docker image in Docker Hub.  This (hopefully) fixes this issue.

Also updated all action versions in all workflows to account for the fact that Node 16 has been deprecated.  New versions use Node 20.
