### PR TITLE
Remove extra scheduled Medley builds that were added for testing purposes last week

### DIFF
--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -20,8 +20,6 @@ name: "Build/Push Release & Docker"
 on:
   schedule:
     - cron: '0 9 * * 1'
-    - cron: '0 9 * * 2'
-    - cron: '0 9 * * 3'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Removing  from BuildReleaseInclDocker workflow the extra scheduled Medley builds that were added for testing purposes last week (since there is no way to test scheduled workflows on a non-main branch).