### PR TITLE
Update buildReleaseIncDocker workflow to automatically kick off a buildAndDeployMedleyDocker workflow in the online repo

### DIFF
--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -116,7 +116,6 @@ jobs:
   # Build Online Docker and Deploy it to Online
   # , do_release, do_docker]
   do_online:
-    if: inputs.draft != 'true'
     needs: [inputs]
     uses: Interlisp/online/.github/workflows/buildAndDeployMedleyDocker.yml@master
     with:

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -123,5 +123,4 @@ jobs:
         run: |
           gh workflow run buildAndDeployMedleyDocker.yml --repo Interlisp/online
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ONLINE_TOKEN }}

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -90,6 +90,7 @@ jobs:
 
   # Build Loadup
   do_release:
+    if: 'yes' == 'no'
     needs: inputs
     uses: ./.github/workflows/buildLoadup.yml
     with:
@@ -102,6 +103,7 @@ jobs:
 
   # Build Docker Image
   do_docker:
+    if: 'yes' == 'no'
     needs: [inputs, do_release]
     uses: ./.github/workflows/buildDocker.yml
     with:
@@ -112,10 +114,14 @@ jobs:
 ######################################################################################
 
   # Build Online Docker and Deploy it to Online
+  # , do_release, do_docker]
   do_online:
     if: inputs.draft != 'true'
-    needs: [inputs, do_release, do_docker]
+    needs: [inputs]
     uses: Interlisp/online/.github/workflows/buildAndDeployMedleyDocker.yml@master
     with:
         platform: 'linux/amd64'
-    secrets: inherit
+    secrets:
+      CCRYPT_KEY: ${{ secrets.CCRYPT_KEY }}
+      OIO_SSH_KEY: ${{ secrets.OIO_SSH_KEY }}
+

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -111,3 +111,11 @@ jobs:
 
 ######################################################################################
 
+  # Build Online Docker and Deploy it to Online
+  do_online:
+    if: inputs.draft != 'true'
+    needs: [inputs, do_release, do_docker]
+    uses: Interlisp/online/.github/workflows/buildDocker.yml
+    with:
+        platform: 'linux/amd64'
+    secrets: inherit

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -117,7 +117,7 @@ jobs:
   # , do_release, do_docker]
   do_online:
     needs: [inputs]
-    uses: Interlisp/online/.github/workflows/buildAndDeployMedleyDocker.yml@master
+    uses: Interlisp/online/.github/workflows/buildAndDeployMedleyDocker.yml@fgh_debug-deploy
     with:
         platform: 'linux/amd64'
     secrets:

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -116,11 +116,11 @@ jobs:
   # Build Online Docker and Deploy it to Online
   # , do_release, do_docker]
   do_online:
+    runs-on: ubuntu-latest
     needs: [inputs]
-    uses: Interlisp/online/.github/workflows/buildAndDeployMedleyDocker.yml@fgh_debug-deploy
-    with:
-        platform: 'linux/amd64'
-    secrets:
-      CCRYPT_KEY: ${{ secrets.CCRYPT_KEY }}
-      OIO_SSH_KEY: ${{ secrets.OIO_SSH_KEY }}
-
+    steps:
+      - name: run-online-deploy
+        run: |
+          gh workflow run buildAndDeployMedleyDocker.yml --repo Interlisp/online --ref master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -115,7 +115,7 @@ jobs:
   do_online:
     if: inputs.draft != 'true'
     needs: [inputs, do_release, do_docker]
-    uses: Interlisp/online/.github/workflows/buildDocker.yml
+    uses: Interlisp/online/.github/workflows/buildDocker.yml@master
     with:
         platform: 'linux/amd64'
     secrets: inherit

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -3,6 +3,7 @@
 #
 # Interlisp webflow to build a Medley release and push it to github.
 # And to build a multiplatform Docker image for the release and push it to Docker Hub.
+# And to kickoff a build and deploy workflow for Medley-online within the online repo.
 #
 # This workflow just calls two reuseable workflows to the two task:
 # buildLoadup.yml and buildDocker.yml
@@ -14,12 +15,12 @@
 # ******************************************************************************
 
 
-name: "Build/Push Release & Docker"
+name: "Build/Push Release, Docker, OIO"
 
 # Run this workflow on ...
 on:
   schedule:
-    - cron: '0 9 * * 3'
+    - cron: '17 9 * * 3'
 
   workflow_dispatch:
     inputs:
@@ -90,7 +91,6 @@ jobs:
 
   # Build Loadup
   do_release:
-    if: false
     needs: inputs
     uses: ./.github/workflows/buildLoadup.yml
     with:
@@ -103,7 +103,6 @@ jobs:
 
   # Build Docker Image
   do_docker:
-    if: false
     needs: [inputs, do_release]
     uses: ./.github/workflows/buildDocker.yml
     with:
@@ -113,14 +112,16 @@ jobs:
 
 ######################################################################################
 
-  # Build Online Docker and Deploy it to Online
-  # , do_release, do_docker]
-  do_online:
+  # Kickoff workflow in online repo to build and deploy Medley docker image to oio
+  do_oio:
     runs-on: ubuntu-latest
-    needs: [inputs]
+    needs: [inputs, do_docker]
     steps:
-      - name: run-online-deploy
+      - name: trigger-oio-buildAndDeploy
         run: |
-          gh workflow run buildAndDeployMedleyDocker.yml --repo Interlisp/online
+          if [ ! "${{ needs.inputs.outputs.draft }}" = "true" ]
+          then
+            gh workflow run buildAndDeployMedleyDocker.yml --repo Interlisp/online --ref master
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.ONLINE_TOKEN }}

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -90,7 +90,7 @@ jobs:
 
   # Build Loadup
   do_release:
-    if: 'yes' == 'no'
+    if: false
     needs: inputs
     uses: ./.github/workflows/buildLoadup.yml
     with:
@@ -103,7 +103,7 @@ jobs:
 
   # Build Docker Image
   do_docker:
-    if: 'yes' == 'no'
+    if: false
     needs: [inputs, do_release]
     uses: ./.github/workflows/buildDocker.yml
     with:

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -121,6 +121,7 @@ jobs:
     steps:
       - name: run-online-deploy
         run: |
-          gh workflow run buildAndDeployMedleyDocker.yml --repo Interlisp/online --ref master
+          gh workflow run buildAndDeployMedleyDocker.yml --repo Interlisp/online
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -115,7 +115,7 @@ jobs:
   do_online:
     if: inputs.draft != 'true'
     needs: [inputs, do_release, do_docker]
-    uses: Interlisp/online/.github/workflows/buildDocker.yml@master
+    uses: Interlisp/online/.github/workflows/buildAndDeployMedleyDocker.yml@master
     with:
         platform: 'linux/amd64'
     secrets: inherit


### PR DESCRIPTION
With this change, whenever a new Medley release and docker image is built successfully (e.g., every Wed morning) then a new online.interlisp.org Medley image will be built and deployed to the online.interlisp.org server. 