### PR TITLE
Update github action workflows to account for deprecation of macos-12 runner and move of ubuntu-latest runner to ubuntu-24.04

### DIFF
--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -70,7 +70,7 @@ jobs:
   # based on the latest commit to the repo
 
   sentry:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       release_not_built: ${{ steps.check.outputs.release_not_built }}
 
@@ -99,7 +99,7 @@ jobs:
 
   build_and-push:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     needs: [sentry]
     if: |
@@ -211,7 +211,7 @@ jobs:
 
   complete:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     outputs:
       build_successful: ${{ steps.output.outputs.build_successful }}

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -333,7 +333,7 @@ jobs:
   #
   macos_installer:
 
-    runs-on: macos-latest
+    runs-on: macos-14
 
     needs: [sentry, loadup]
     if: |

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -333,7 +333,7 @@ jobs:
   #
   macos_installer:
 
-    runs-on: macos-12
+    runs-on: macos-latest
 
     needs: [sentry, loadup]
     if: |

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -66,7 +66,7 @@ jobs:
   # based on the latest commit to the repo
 
   sentry:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       release_not_built: ${{ steps.check.outputs.release_not_built }}
 
@@ -96,7 +96,7 @@ jobs:
 
   loadup:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     outputs:
       combined_release_tag: ${{ steps.job_outputs.outputs.COMBINED_RELEASE_TAG }}
@@ -257,7 +257,7 @@ jobs:
   #
   linux_installer:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     needs: [sentry, loadup]
     if: |
@@ -507,7 +507,7 @@ jobs:
 
   downloads_page:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     needs: [sentry, loadup, linux_installer, macos_installer, cygwin_installer]
     if: |
@@ -606,7 +606,7 @@ jobs:
 
   complete:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     outputs:
       build_successful: ${{ steps.output.outputs.build_successful }}

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -69,7 +69,7 @@ jobs:
   # the result of a workflow_dispatch or a workflow_call
 
   inputs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       draft: ${{ steps.one.outputs.draft }}
       force: ${{ steps.one.outputs.force }}
@@ -124,7 +124,7 @@ jobs:
 
   # Kickoff workflow in online repo to build and deploy Medley docker image to oio
   do_oio:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [inputs, do_docker]
     steps:
       - name: trigger-oio-buildAndDeploy

--- a/.github/workflows/doHCFILES.yml
+++ b/.github/workflows/doHCFILES.yml
@@ -45,7 +45,7 @@ jobs:
 
   run_HCFILES:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
 


### PR DESCRIPTION
Update github action workflows to account for deprecation of macos-12 runner and move of ubuntu-latest to ubuntu-24.04.  

Removed use of ubuntu-latest and macos-latest in favor of explicit versions (macos-14, ubuntu-24.04) in order to prevent issues when *-latest changes without our notice.
