### PR TITLE
Fix Issue #1868: Cygwin installer now handles install directory with spaces in its name.

### DIFF
--- a/installers/cygwin/.gitignore
+++ b/installers/cygwin/.gitignore
@@ -4,3 +4,4 @@ maiko*.tgz
 setup-x86_64.exe
 medley.bat
 
+

--- a/installers/cygwin/medley.iss
+++ b/installers/cygwin/medley.iss
@@ -9,7 +9,6 @@
 ;#
 ;###############################################################################
 
-#define x86_or_x64 "x64"
 #if GetEnv('COMBINED_RELEASE_TAG') != ""
 #define VERSION=GetEnv('COMBINED_RELEASE_TAG')
 #else
@@ -24,20 +23,17 @@
 
 [Setup]
 PrivilegesRequired=lowest
-ArchitecturesAllowed={#x86_or_x64}
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
 AppName=Medley
 AppVersion={#version}
 AppPublisher=Interlisp.org
 AppPublisherURL=https://interlisp.org/
-AppCopyright=Copyright (C) 2023 Interlisp.org
-DefaultDirName={%USERPROFILE}\il
+AppCopyright=Copyright (C) 2023-2024 Interlisp.org
+DefaultDirName="{%USERPROFILE}\il"
 DefaultGroupName=Medley
 Compression=lzma2
 SolidCompression=yes
-; "ArchitecturesInstallIn64BitMode=x64" requests that the install be
-; done in "64-bit mode" on x64, meaning it should use the native
-; 64-bit Program Files directory and the 64-bit view of the registry.
-ArchitecturesInstallIn64BitMode=x64
 OutputDir="."
 OutputBaseFilename={#OUTFILE}
 SetupIconFile="Medley.ico"
@@ -48,7 +44,7 @@ WizardImageFile=medley_logo.bmp
 WizardSmallImageFile=medley_logo_small.bmp
 WizardImageStretch=no
 UninstallDisplayIcon="{app}\Medley.ico"
-UninstallFilesDir={app}\uninstall
+UninstallFilesDir="{app}\uninstall"
 UsePreviousAppDir=no
 
 [Dirs]
@@ -68,18 +64,21 @@ Name: "{group}\Medley\Uninstall_Medley"; Filename: "{uninstallexe}"
 ; Name: "{group}\Medley\Medley"; Filename: "powershell"; Parameters: "-NoExit -File {app}\medley.ps1 --help"; IconFilename: "{app}\Medley.ico"
 
 [Run]
-Filename: "{app}\cygwin\setup-x86_64.exe"; Parameters: "--quiet-mode --no-admin --wait --no-shortcuts --no-write-registry --verbose --root {app} --site https://mirrors.kernel.org/sourceware/cygwin --only-site --local-package-dir {app}\cygwin --packages nano,xdg-utils"; StatusMsg: "Installing Cygwin ..."
+Filename: "{app}\cygwin\setup-x86_64.exe"; Parameters: "--quiet-mode --no-admin --wait --no-shortcuts --no-write-registry --verbose --root ""{app}"" --site https://mirrors.kernel.org/sourceware/cygwin --only-site --local-package-dir ""{app}\cygwin"" --packages nano,xdg-utils"; StatusMsg: "Installing Cygwin ..."
 Filename: "{app}\bin\bash"; Parameters: "-login -c 'sed -i -e s/^none/#none/ /etc/fstab && echo none / cygdrive binary,posix=0,user 0 0 >>/etc/fstab'"; Flags: runhidden
-Filename: "tar"; Parameters: "-x -z -C {app} -f {app}\install\medley.tgz"; Flags: runhidden; StatusMsg: "Installing Medley ..."
-Filename: "powershell"; Parameters: "remove-item -force -recurse {app}\maiko"; Flags: runhidden; StatusMsg: "Installing Maiko ..."
-Filename: "tar"; Parameters: "-x -z -C {app} -f {app}\install\maiko-cygwin.x86_64.tgz"; Flags: runhidden; StatusMsg: "Installing Maiko ..."
+Filename: "tar"; Parameters: "-x -z -C ""{app}"" -f ""{app}\install\medley.tgz"""; Flags: runhidden; StatusMsg: "Installing Medley ..."
+Filename: "powershell"; Parameters: "remove-item -force -recurse ""{app}\maiko"""; Flags: runhidden; StatusMsg: "Installing Maiko ..."
+Filename: "tar"; Parameters: "-x -z -C ""{app}"" -f ""{app}\install\maiko-cygwin.x86_64.tgz"""; Flags: runhidden; StatusMsg: "Installing Maiko ..."
 ; Recreate medley symbolic links (lost in tars)
 Filename: "{app}\bin\bash"; Parameters: "-login -c 'cd /medley/scripts/medley && ln -s medley.command medley.sh && cd ../.. && ln -s /medley/scripts/medley/medley.sh medley'"; Flags: runhidden
 ; Create medley.bat
-Filename: "powershell"; Parameters: "write-output \""{app}\bin\bash -login -c '/medley/scripts/medley/medley.sh %*'\""  | out-file medley.bat -Encoding ascii"; WorkingDir: "{app}"; Flags: runhidden; StatusMsg: "Creating medley.bat ..."
-Filename: "{app}\uninstall\EditPath.exe"; Parameters: "--user --add {app}"; Flags: runhidden; StatusMsg: "Adding to PATH ..."
-Filename: "powershell"; Parameters: "remove-item -recurse -force {app}\install"; Flags: runhidden; StatusMsg: "Cleaning up ..."
+Filename: "powershell"; Parameters: "write-output '""""""""{app}\bin\bash"""""""" -login -c """"""""/medley/scripts/medley/medley.sh %*""""""""'  | out-file medley.bat -Encoding ascii -NoNewline"; WorkingDir: "{app}"; Flags: runhidden; StatusMsg: "Creating medley.bat ..."
+Filename: "{app}\uninstall\EditPath.exe"; Parameters: "--user --add ""{app}"""; Flags: runhidden; StatusMsg: "Adding to PATH ..."
+Filename: "powershell"; Parameters: "remove-item -recurse -force """"""""{app}\install"""""""""; Flags: runhidden; StatusMsg: "Cleaning up ..."
+
+[UninstallDelete]
+Type: filesandordirs; Name: "{app}"
 
 [UninstallRun]
-Filename: "{app}\uninstall\EditPath.exe"; Parameters: "--user --remove {app}"; Flags: runhidden 
+Filename: "{app}\uninstall\EditPath.exe"; Parameters: "--user --remove ""{app}"""; Flags: runhidden 
 

--- a/installers/cygwin/prep-for-local-testing.ps1
+++ b/installers/cygwin/prep-for-local-testing.ps1
@@ -1,0 +1,9 @@
+#
+#  Prep the installer/cygwin directory to locally test the medley.iss installer
+#  Normally these downloads are done by the github workflow
+#
+#  fgh 2024-11-15
+#
+wget https://cygwin.com/setup-x86_64.exe -OutFile setup-x86_64.exe
+gh release download --repo interlisp/maiko --pattern *-cygwin.x86_64.tgz --output maiko-cygwin.x86_64.tgz --clobber
+gh release download --repo interlisp/medley --pattern medley-full-linux-x86_64-*.tgz --output medley.tgz --clobber


### PR DESCRIPTION
Cygwin installer now handles install directory with spaces in its name (see Issue 1868)

Also fixed the uninstall script do that it actually deletes all of the installed files.  Previously was deleting just some of the files.

Also added a powershell script that makes the local testing of the cygwin installer easier.

A cygwin installer that includes this PR can be found here: [https://github.com/Interlisp/medley/releases/download/untagged-532549860f120d8f9812/medley-full-cygwin-x86_64-241114-28315513_241110-e68fb0dd.exe](https://github.com/Interlisp/medley/releases/download/untagged-532549860f120d8f9812/medley-full-cygwin-x86_64-241114-28315513_241110-e68fb0dd.exe)