### PR TITLE
loadup-lfg.sh script to create lfg.sysout - to be installed and run from LFG directory

### DIFF
--- a/scripts/loadup-app-setup.sh
+++ b/scripts/loadup-app-setup.sh
@@ -1,0 +1,135 @@
+#!to_be_sourced_only
+# shellcheck shell=sh
+
+
+MEDLEY_SCRIPTDIR="$(cd "${MEDLEYDIR}/scripts" && pwd)"
+
+if [ -z "${APP_DIR}" ]
+then
+  export APP_DIR="$(cd "${LOADUP_SCRIPTDIR}/../" && pwd)"
+fi
+
+if [ ! -d "${APP_DIR}" ]
+then
+  echo "Error: Cannot find the LFG directory: ${APP_DIR}"
+  exit 1
+fi
+
+if [ -z "${APP_LOADUPSDIR}" ]
+then
+  export APP_LOADUPSDIR="${APP_DIR}/loadups"
+fi
+
+if [ ! -d "${APP_LOADUPSDIR}" ]
+then
+  if [ -e "${APP_LOADUPSDIR}" ]
+  then
+    echo "Error: the lfg loadups dir (${APP_LOADUPSDIR}) exists, but it is not a directory."
+    echo "Exiting."
+    exit 1
+  else
+    mkdir -p "${APP_LOADUPSDIR}"
+  fi
+fi
+
+if [ -z "${APP_WORKDIR}" ]
+then
+  export APP_WORKDIR="${APP_LOADUPSDIR}/build"
+fi
+
+if [ ! -d "${APP_WORKDIR}" ]
+then
+  if [ -e "${APP_WORKDIR}" ]
+  then
+    echo "Error: the lfg loadups work dir (${APP_WORKDIR}) exists, but it is not a directory."
+    echo "Exiting."
+    exit 1
+  else
+    mkdir -p "${APP_WORKDIR}"
+  fi
+fi
+
+HAS_GIT= [ -f $(which git) ] && [ -x $(which git) ]
+export HAS_GIT
+
+git_commit_ID () {
+  if ${HAS_GIT};
+  then
+    # This does NOT indicate if there are any modified files!
+    COMMIT_ID=$(git -C "$1" rev-parse --short HEAD 2>/dev/null)
+  fi
+}
+
+git_commit_ID "${MEDLEYDIR}"
+MEDLEY_COMMIT_ID="${COMMIT_ID}"
+export MEDLEY_COMMIT_ID
+
+git_commit_ID "${APP_DIR}"
+APP_COMMIT_ID="${COMMIT_ID}"
+export APP_COMMIT_ID
+
+
+scr="-sc 1024x768 -g 1042x790"
+geometry=1024x768
+
+touch "${APP_WORKDIR}"/loadup.timestamp
+
+script_name=$(basename "$0" ".sh")
+cmfile="${APP_WORKDIR}/${script_name}.cm"
+
+
+######################################################################
+
+loadup_start () {
+  echo ">>>>> START ${script_name}"
+}
+
+loadup_finish () {
+  rm -f "${cmfile}"
+# 2024-05-05 FGH
+# Can't use exit code for now since on MacOS exit codes appear to be inverted
+# Will restore once MacOS exit code are figured out
+#  if [ "${exit_code}" -ne 0 ] || [ ! -f "${LOADUP_WORKDIR}/$1" ]
+  if [ ! -f "${APP_WORKDIR}/$1" ]
+  then
+    echo "----- FAILURE -----"
+    exit_code=1
+  else
+    echo
+    echo "..... files copied into loadups ....."
+    for f in "$@"
+    do
+      # shellcheck disable=SC2045,SC2086
+      for ff in $(ls -1 "${APP_WORKDIR}"/$f);
+      do
+        /bin/sh "${MEDLEY_SCRIPTDIR}/cpv" "${ff}" "${APP_LOADUPSDIR}"       \
+                | sed -e "s#${APP_DIR}/##g"
+      done
+    done
+    echo "....................................."
+    echo
+    echo "+++++ SUCCESS +++++"
+    exit_code=0
+  fi
+  echo "<<<<< END ${script_name}"
+  echo ""
+  exit ${exit_code}
+}
+
+run_medley () {
+    /bin/sh "${MEDLEYDIR}/scripts/medley/medley.command"  \
+             --config -                                          \
+             --id loadup_+                                       \
+             --geometry "${geometry}"                            \
+             --noscroll                                          \
+             --logindir "${APP_WORKDIR}"                         \
+             --greet "${cmfile}"                                 \
+             --sysout "$1"                                       \
+             "$2" "$3" "$4" "$5" "$6" "$7"                       ;
+    exit_code=$?
+
+}
+
+######################################################################
+
+

--- a/scripts/loadup-app-setup.sh
+++ b/scripts/loadup-app-setup.sh
@@ -11,7 +11,7 @@ fi
 
 if [ ! -d "${APP_DIR}" ]
 then
-  echo "Error: Cannot find the LFG directory: ${APP_DIR}"
+  echo "Error: Cannot find the ${APP_NAME} directory: ${APP_DIR}"
   exit 1
 fi
 
@@ -24,7 +24,7 @@ if [ ! -d "${APP_LOADUPSDIR}" ]
 then
   if [ -e "${APP_LOADUPSDIR}" ]
   then
-    echo "Error: the lfg loadups dir (${APP_LOADUPSDIR}) exists, but it is not a directory."
+    echo "Error: the ${APP_NAME} loadups dir (${APP_LOADUPSDIR}) exists, but it is not a directory."
     echo "Exiting."
     exit 1
   else
@@ -41,7 +41,7 @@ if [ ! -d "${APP_WORKDIR}" ]
 then
   if [ -e "${APP_WORKDIR}" ]
   then
-    echo "Error: the lfg loadups work dir (${APP_WORKDIR}) exists, but it is not a directory."
+    echo "Error: the ${APP_NAME} loadups work dir (${APP_WORKDIR}) exists, but it is not a directory."
     echo "Exiting."
     exit 1
   else
@@ -90,11 +90,8 @@ loadup_finish () {
 # Can't use exit code for now since on MacOS exit codes appear to be inverted
 # Will restore once MacOS exit code are figured out
 #  if [ "${exit_code}" -ne 0 ] || [ ! -f "${LOADUP_WORKDIR}/$1" ]
-  if [ ! -f "${APP_WORKDIR}/$1" ]
+  if [ "${APP_WORKDIR}/$1" -nt "${APP_WORKDIR}"/loadup.timestamp ]
   then
-    echo "----- FAILURE -----"
-    exit_code=1
-  else
     echo
     echo "..... files copied into loadups ....."
     for f in "$@"
@@ -110,6 +107,9 @@ loadup_finish () {
     echo
     echo "+++++ SUCCESS +++++"
     exit_code=0
+  else
+    echo "----- FAILURE -----"
+    exit_code=1
   fi
   echo "<<<<< END ${script_name}"
   echo ""

--- a/scripts/loadup-lfg.sh
+++ b/scripts/loadup-lfg.sh
@@ -2,9 +2,9 @@
 
 main() {
 
-        APP_DIR="${LFG_DIR}"
-        APP_LOADUPSDIR="${LFG_LOADUPSDIR}"
-        APP_WORKDIR="${LFG_WORKDIR}"
+        export APP_DIR="${LFG_DIR}"
+        export APP_LOADUPSDIR="${LFG_LOADUPSDIR}"
+        export APP_WORKDIR="${LFG_WORKDIR}"
 
         get_medleydir "$@"
 

--- a/scripts/loadup-lfg.sh
+++ b/scripts/loadup-lfg.sh
@@ -1,0 +1,190 @@
+#!/bin/sh
+
+main() {
+
+        APP_DIR="${LFG_DIR}"
+        APP_LOADUPSDIR="${LFG_LOADUPSDIR}"
+        APP_WORKDIR="${LFG_WORKDIR}"
+
+        get_medleydir "$@"
+
+        loadup_start
+
+	cat >"${cmfile}" <<-"EOF"
+	"
+
+	(PROGN
+	   (IL:MEDLEY-INIT-VARS 'IL:GREET)
+	   (IL:DRIBBLE (IL:PACKFILENAME 'HOST '{DSK} 'DIRECTORY (IL:UNIX-GETENV 'APP_WORKDIR) 'NAME 'lfg.dribble))
+	   (IL:DOFILESLOAD
+               '((SYSLOAD)
+                 (FROM VALUEOF (IL:PACKFILENAME 'HOST '{DSK} 'DIRECTORY (IL:UNIX-GETENV 'APP_DIR)))
+                 LFG-LOADUP
+                )
+           )
+           (IL:LOADUP-LFG)
+           (IL:PUTASSOC 'IL:LFG
+                        (LIST (IL:UNIX-GETENV 'MEDLEY_COMMIT_ID))
+                        (CADR (ASSOC 'IL:MEDLEY IL:SYSOUTCOMMITS)))
+           (IL:PUTASSOC 'IL:LFG (LIST (IL:UNIX-GETENV 'APP_COMMIT_ID)) IL:SYSOUTCOMMITS)
+	   (IL:ENDLOADUP)
+	   (IL:DRIBBLE)
+	   (IL:MAKESYS
+	       (IL:PACKFILENAME 'HOST '{DSK} 'DIRECTORY (IL:UNIX-GETENV 'APP_WORKDIR) 'NAME 'lfg.sysout)
+	       :LFG
+           )
+	)
+	(IL:LOGOUT T)
+
+	"
+	EOF
+
+	run_medley "${full_sysout}"
+
+        loadup_finish "lfg.sysout" "lfg.dribble"
+
+}
+
+get_medleydir() {
+
+	while [ $# -gt 0 ]
+        do
+          case "$1" in
+            -m | -medley | --medley)
+              export MEDLEYDIR="$2"
+              if [ -z "$2" ]
+              then
+                echo "Error: The -m (-medley, --medley) flag requires a path to a full.sysout file as an argument"
+                echo "Exiting"
+                exit 1
+              fi
+              shift
+              ;;
+            *)
+              echo "Warning unknown argument: $1.  Ignored"
+              ;;
+          esac
+          shift
+        done
+
+        if [ -z "${MEDLEYDIR}" ]
+        then
+          echo "Error: MEDLEYDIR not specified either thru environment variable or thru command line argument"
+          echo "Exiting"
+          exit 1
+        fi
+
+        full_sysout="${MEDLEYDIR}/loadups/full.sysout"
+        if [ ! -f "${full_sysout}" ]
+        then
+          echo "Error: cannot find the Medley full.sysout file (${full_sysout})"
+          echo "It either doesn't exist or is a directory"
+          echo "Exiting"
+          exit 1
+        fi
+
+        . "${MEDLEYDIR}/scripts/loadup-app-setup.sh"
+
+}
+
+
+# shellcheck disable=SC2164,SC2034
+if [ -z "${LOADUP_SCRIPTDIR}" ]
+then
+	#
+	#
+	# Some functions to determine what directory this script is being executed from
+	#
+	#
+	get_abs_filename() {
+	  # $1 : relative filename
+	  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+	}
+
+	# This function taken from
+	# https://stackoverflow.com/questions/29832037/how-to-get-script-directory-in-posix-sh
+	rreadlink() (
+
+	  # Execute this function in a *subshell* to localize variables and the effect of `cd`.
+
+	  target=$1
+	  fname=
+	  targetDir=
+	  CDPATH=
+
+	  # Try to make the execution environment as predictable as possible:
+	  # All commands below are invoked via `command`, so we must make sure that `command`
+	  # itself is not redefined as an alias or shell function.
+	  # (Note that command is too inconsistent across shells, so we don't use it.)
+	  # `command` is a *builtin* in bash, dash, ksh, zsh, and some platforms do not even have
+	  # an external utility version of it (e.g, Ubuntu).
+	  # `command` bypasses aliases and shell functions and also finds builtins 
+	  # in bash, dash, and ksh. In zsh, option POSIX_BUILTINS must be turned on for that
+	  # to happen.
+	  { \unalias command; \unset -f command; } >/dev/null 2>&1
+	  [ -n "$ZSH_VERSION" ] && options[POSIX_BUILTINS]=on # make zsh find *builtins* with `command` too.
+
+	  while :; do # Resolve potential symlinks until the ultimate target is found.
+	      [ -L "$target" ] || [ -e "$target" ] || { command printf '%s\n' "ERROR: '$target' does not exist." >&2; return 1; }
+	      command cd "$(command dirname -- "$target")" # Change to target dir; necessary for correct resolution of target path.
+	      fname=$(command basename -- "$target") # Extract filename.
+	      [ "$fname" = '/' ] && fname='' # !! curiously, `basename /` returns '/'
+	      if [ -L "$fname" ]; then
+	        # Extract [next] target path, which may be defined
+	        # *relative* to the symlink's own directory.
+	        # Note: We parse `ls -l` output to find the symlink target
+	        #       which is the only POSIX-compliant, albeit somewhat fragile, way.
+	        target=$(command ls -l "$fname")
+	        target=${target#* -> }
+	        continue # Resolve [next] symlink target.
+	      fi
+	      break # Ultimate target reached.
+	  done
+	  targetDir=$(command pwd -P) # Get canonical dir. path
+	  # Output the ultimate target's canonical path.
+	  # Note that we manually resolve paths ending in /. and /.. to make sure we have a normalized path.
+	  if [ "$fname" = '.' ]; then
+	    command printf '%s\n' "${targetDir%/}"
+	  elif  [ "$fname" = '..' ]; then
+	    # Caveat: something like /var/.. will resolve to /private (assuming /var@ -> /private/var), i.e. the '..' is applied
+	    # AFTER canonicalization.
+	    command printf '%s\n' "$(command dirname -- "${targetDir}")"
+	  else
+	    command printf '%s\n' "${targetDir%/}/$fname"
+	  fi
+	)
+
+	get_script_dir() {
+
+	    # call this with $0 (from main script) as its (only) parameter
+	    # if you need to preserve cwd, run this is a subshell since
+	    # it can change cwd
+
+	    # set -x
+
+	    local_SCRIPT_PATH="$( get_abs_filename "$1" )";
+
+	    while [ -h "$local_SCRIPT_PATH" ];
+	    do
+	        cd "$( dirname -- "$local_SCRIPT_PATH"; )";
+	        local_SCRIPT_PATH="$( rreadlink "$local_SCRIPT_PATH" )";
+	    done
+
+	    cd "$( dirname -- "$local_SCRIPT_PATH"; )" > '/dev/null';
+	    local_SCRIPT_PATH="$( pwd; )";
+
+	    # set +x
+
+	    echo "${local_SCRIPT_PATH}"
+	}
+
+	# end of script directory functions
+	###############################################################################
+
+        # figure out the script dir
+        LOADUP_SCRIPTDIR="$(get_script_dir "$0")"
+	export LOADUP_SCRIPTDIR
+
+fi
+
+main "$@"


### PR DESCRIPTION
NOTE: This PR is completely independent of the standard medley loadup scripts and any PR related thereof.

This PR contains 2 new files (in the MEDLEYDIR/scripts directory).

The first file `loadup-lfg.sh` needs to be copied into LFGDIR/scripts.   Note that the "Lisp-ish CM here-doc" included in this file needs to updated to account for how LFG is actually loaded.  What's there now is just a skeleton for testing.
Also if there are more outputs of the loadup process that need to be preserved, then the line starting with `loadup_finish` will need to be updated accordingly. 

The second file `loadup-app-setup.sh` is to remain in MELDEYDIR/scripts directory. NOTE: until this PR is integrated AND the file is spread throughout all MEDLEYDIRs used for LFG,  you will need to copy this file into MEDLEYDIR/scripts for all MEDLEYDIRs you want to use as a basis for lfg.sysout.

To build a lfg.sysout, run `LFGDIR/scripts/loadup-lfg.sh`.  You will need to specify a MEDLEYDIR to pull full.sysout from (and to host the second aforementioned file).  You can specify the MEDLEYDIR either by setting the MEDLEYDIR env variable OR by using the `-m <path to medley dir>` command-line argument.  (Note: -medley and --medley are synonyms for -m.)

By default, LFGDIR is set to the (parent of) the directory that the loadup-lfg script is being executed from.  And the loadup build happens in LFGDIR/loadups/build.  If the loadup is successful, the lfg.sysout and lfg.dribble files are copied into LFGDIR/loadup.  

To change these defaults set the following env variables: LFG_DIR, LFG_WORKDIR and LFG_LOADUPSDIR.  Any directories specified in this way must already exist - the script will not create them.

Again all of this does not depend on any of the medley loadup scripts.