### PR TITLE
Add command line option to set maiko runtime debug level.

### DIFF
--- a/scripts/medley/medley.command
+++ b/scripts/medley/medley.command
@@ -582,6 +582,8 @@ flags:
 
     -r - | --greet -           : do not use a greetfile
 
+    -rtd N | --runtime_debug N : Enable maiko runtime debug output at level N (integer)
+
     -x DIR | --logindir DIR    : use DIR as LOGINDIR in Medley
 
     -x - | --logindir -        : use MEDLEYDIR/logindir as LOGINDIR in Medley
@@ -929,6 +931,11 @@ do
         ;;
       --)
         pass_args=true
+        ;;
+      -rtd | --runtime_debug)
+        LDERUNTIMEDEBUG="$2"
+        export LDERUNTIMEDEBUG
+        shift
         ;;
       -*)
         usage "ERROR: Unknown flag: $1"

--- a/scripts/medley/medley_args.sh
+++ b/scripts/medley/medley_args.sh
@@ -347,6 +347,11 @@ do
       --)
         pass_args=true
         ;;
+      -rtd | --runtime_debug)
+        LDERUNTIMEDEBUG="$2"
+        export LDERUNTIMEDEBUG
+        shift
+        ;;
       -*)
         usage "ERROR: Unknown flag: $1"
         ;;

--- a/scripts/medley/medley_usage.sh
+++ b/scripts/medley/medley_usage.sh
@@ -111,6 +111,8 @@ flags:
 
     -r - | --greet -           : do not use a greetfile
 
+    -rtd N | --runtime_debug N : Enable maiko runtime debug output at level N (integer)
+
     -x DIR | --logindir DIR    : use DIR as LOGINDIR in Medley
 
     -x - | --logindir -        : use MEDLEYDIR/logindir as LOGINDIR in Medley


### PR DESCRIPTION
Add command line option (-rtd N | --runtime_debug N) to set maiko runtime debug level to N.

This supports maiko branch: mth38--support-runtime-debug-output.

This is draft as it probably isn't generally applicable. OTOH, it's also relatively harmless (as of now).