### PR TITLE
Fix Medley builds on github actions - currently breaks due to error in creating Docker image for arm64.

### DIFF
--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -154,7 +154,8 @@ jobs:
           if [ "${{ inputs.draft }}" = "false" ];
           then
               docker_tags="${docker_image}:latest,${docker_image}:${MEDLEY_RELEASE#*-}_${MAIKO_RELEASE#*-}"
-              platforms="linux/amd64,linux/arm64"
+              platforms="linux/amd64"
+              #,linux/arm64
           else
               docker_tags="${docker_image}:draft"
               platforms="linux/amd64"
@@ -171,7 +172,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
         with:
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64
+       # ,linux/arm64,linux/arm/v7
 
       # Setup the Docker Buildx funtion
       - name: Set up Docker Buildx


### PR DESCRIPTION
The Medley automated builds currently are failing due to an error in loading the tigervnc-standalone-server package while creating the Medley Docker image for arm64.  The analogous build for amd64 works just fine.

"Fixed" by eliminating the Medley Docker image build for arm64.  We don't currently use, and have never in the past used, the arm64 Medley Docker image.  It was created to enable moving online to an arm64 server rather than an intel server.  But we have no plans to do this.  So easiest "fix" is just to comment out the arm64 Docker image build for now (or maybe forever) while the Ubuntu/qemu/tigervnc folks figure out what's going on with "apt-get install tigervnc-standalone-server" on qemu/arm64 platform.
