### PR TITLE
Fix error in lsee RegEx to replace ^ with ↑

### DIFF
--- a/scripts/lsee
+++ b/scripts/lsee
@@ -13,7 +13,7 @@
 export LANG=en_US.UTF-8
 tr '\r' '\n' < $1 | \
     sed -e 's/_/←/g'        \
-	-e 's/^/↑/g'        \
+	-e 's/\^/↑/g'        \
 	-e 's//[0m/g' \
 	-e 's//[31m/g'\
 	-e 's//[1m/g' \


### PR DESCRIPTION
The RegEx in lsee to replace `^` with `↑` didn't quote (backslash) the `^` so it was interpreted as the start of line pattern.

Fixes Discussion #2137

I noticed that this will not convert `\r\n` to `\n`, but only changes the `\r` to `\n` which, for a files with `cr-lf` end-of-line, would result in double line spacing. This case shouldn't happen, but could (especially on Windows) by an improperly setup git, or editing a file in a Windows text editor.