### PR TITLE
Fix Issue #2155 by reordering  in the loadup script the component loadups and when their outputs are copied into loadups dir.

### DIFF
--- a/scripts/loadups/loadup
+++ b/scripts/loadups/loadup
@@ -18,6 +18,7 @@ main() {
         thinw=false
         thinl=false
         override_lock=false
+        ignore_lock=false
         while [ "$#" -ne 0 ];
       	do
           case "$1" in
@@ -148,7 +149,12 @@ main() {
             -ov | -override | --override)
               override_lock=true
               ;;
+            --ignore_lock)
+              # internal
+              ignore_lock=true
+              ;;
             --noendmsg)
+              # internal
               noendmsg=true
               ;;
             -z | -man | --man )
@@ -284,7 +290,7 @@ main() {
         fi
 
         #
-        #  Do individual loadups as requested
+        #  Do individual "stage" loadups as requested
         #
 
         if [ "${no_loadups}" = false ]
@@ -318,23 +324,11 @@ main() {
 	          /bin/sh "${LOADUP_SCRIPTDIR}/loadup-apps-from-full.sh"
 	          exit_if_failure $? "${noendmsg}"
 	        fi
-
-	        if [ "${aux}" = true ]
-	        then
-	          /bin/sh "${LOADUP_SCRIPTDIR}/loadup-aux.sh"
-	          exit_if_failure $? "${noendmsg}"
-	        fi
-
-	        if [ "${db}" = true ]
-	        then
-	          /bin/sh "${LOADUP_SCRIPTDIR}/loadup-db-from-full.sh"
-	          exit_if_failure $? "${noendmsg}"
-	        fi
         fi
 
 
         #
-        #   Done with loadups, successfully.  Now copy files into loadups dir from workdir
+        #   Done with "stage" loadups, successfully.  Now copy the stages files into loadups dir from workdir
         #
 
         if [ "${nocopy}" = false ]
@@ -371,7 +365,29 @@ main() {
 	          /bin/sh "${LOADUP_CPV}" "${LOADUP_WORKDIR}"/apps.dribble "${LOADUP_OUTDIR}"       \
 	              | sed -e "s#${MEDLEYDIR}/##g"
 	        fi
+        fi
 
+
+
+        #
+        #  Now do the "after stages" loadups, if required.  Do the copies as necessary to meet the dependecies
+        #  of one loadup on another's output.
+        #
+
+        # First aux
+
+        if [ "${no_loadups}" = false ]
+        then
+
+	        if [ "${aux}" = true ]
+	        then
+	          /bin/sh "${LOADUP_SCRIPTDIR}/loadup-aux.sh"
+	          exit_if_failure $? "${noendmsg}"
+	        fi
+        fi
+
+        if [ "${nocopy}" = false ]
+        then
 	        if [ "${aux}" = true ]
 	        then
 	          /bin/sh "${LOADUP_CPV}" "${LOADUP_WORKDIR}"/whereis.hash "${LOADUP_OUTDIR}"      \
@@ -383,7 +399,21 @@ main() {
 	          /bin/sh "${LOADUP_CPV}" "${LOADUP_WORKDIR}"/exports.dribble "${LOADUP_OUTDIR}"       \
 	              | sed -e "s#${MEDLEYDIR}/##g"
 	        fi
+        fi
 
+        # then db, which depends on the output of aux
+
+        if [ "${no_loadups}" = false ]
+        then
+                if [ "${db}" = true ]
+	        then
+	          /bin/sh "${LOADUP_SCRIPTDIR}/loadup-db-from-full.sh"
+	          exit_if_failure $? "${noendmsg}"
+	        fi
+        fi
+
+        if [ "${nocopy}" = false ]
+        then
 	        if [ "${db}" = true ]
 	        then
 		  /bin/sh "${LOADUP_CPV}" "${LOADUP_WORKDIR}"/fuller.database "${LOADUP_OUTDIR}"    \
@@ -391,9 +421,12 @@ main() {
 		  /bin/sh "${LOADUP_CPV}" "${LOADUP_WORKDIR}"/fuller.dribble "${LOADUP_OUTDIR}"    \
 	              | sed -e "s#${MEDLEYDIR}/##g"
 	        fi
-
         fi
 
+
+        #
+        #  OK we're done, exit cleanly
+        #
         echo "+++++ loadup: SUCCESS +++++"
         remove_run_lock
         exit 0

--- a/scripts/loadups/loadup-aux.sh
+++ b/scripts/loadups/loadup-aux.sh
@@ -8,6 +8,13 @@ main() {
 
 	loadup_start
 
+	SYSOUT="${LOADUP_OUTDIR}/full.sysout"
+	if [ ! -f "${SYSOUT}" ]
+	then
+	  output_error_msg "Error: cannot find ${SYSOUT}.${EOL}Exiting."
+	  exit 1
+	fi
+
         initfile="-"
 	cat >"${cmfile}" <<-"EOF"
 	"
@@ -33,7 +40,7 @@ main() {
 	"
 	EOF
 
-	run_medley "${LOADUP_WORKDIR}/full.sysout"
+	run_medley "${SYSOUT}"
 
 	loadup_finish "whereis.hash" "whereis.hash" "exports.all"
 }

--- a/scripts/loadups/loadup-db-from-full.sh
+++ b/scripts/loadups/loadup-db-from-full.sh
@@ -6,12 +6,20 @@ main() {
 
 	loadup_start
 
-	SYSOUT="${MEDLEYDIR}/loadups/full.sysout"
-	if [ ! -f "${SYSOUT}" ];
+	SYSOUT="${LOADUP_OUTDIR}/full.sysout"
+	if [ ! -f "${SYSOUT}" ]
 	then
 	  output_error_msg "Error: cannot find ${SYSOUT}.${EOL}Exiting."
 	  exit 1
 	fi
+
+        # Check to make sure exports.all exists and is newer than full.sysout
+        # if not, run loadup-aux to create a new exports.all
+        EXPORTS="${LOADUP_OUTDIR}/exports.all"
+        if [ ! -f "${EXPORTS}" ] || [ "$(find "${SYSOUT}" -newer "${EXPORTS}" -exec echo true \; )" = true ]
+        then
+          "${MEDLEYDIR}"/scripts/loadups/loadup --aux --ignore_lock --noendmsg
+        fi
 
         initfile="-"
 	cat >"${cmfile}" <<-"EOF"

--- a/scripts/loadups/loadup-setup.sh
+++ b/scripts/loadups/loadup-setup.sh
@@ -247,9 +247,13 @@ process_maikodir() {
 }
 
 export LOADUP_LOCKFILE="${LOADUP_WORKDIR}"/lock
+LOADUP_LOCK=""
+override_lock=false
+ignore_lock=false
 
 check_run_lock() {
-    set +x
+  if [ "${ignore_lock}" = false ]
+  then
     if [ -e "${LOADUP_LOCKFILE}" ]
     then
       output_warn_msg "Warning: Another loadup is already running with PID $(cat "${LOADUP_LOCKFILE}")"
@@ -282,6 +286,7 @@ check_run_lock() {
     fi
     echo "$$" > "${LOADUP_LOCKFILE}"
     LOADUP_LOCK="$$"
+  fi
 }
 
 remove_run_lock() {


### PR DESCRIPTION
Fix Issue #2155 (loadup -f -b -x fails can't find full.sysout).  

Reordered when things are done in the loadup scripts such that:
1.  The sysouts are copied to into the loadups dir before the aux and db subscripts are done
2.   Exports.all is copied into the loadups directory before the -db load is done.
3.   If full.sysout is newer than exports.all in the loadups dir, the loadup-aux is run before loadup-db to refresh exports.all.

This ensures that the depended-on files are in place before any particular component loadup is run.

No changes to the command line arguments.