### PR TITLE
Medley script currently forces -vnc when using WSL1.  This PR removes this infelicity.

### DIFF
--- a/scripts/medley/medley.command
+++ b/scripts/medley/medley.command
@@ -1002,12 +1002,6 @@ do
   shift
 done
 
-# if running on WSL1, force use_vnc
-if [ "${wsl}" = true ] && [ "${wsl_ver}" -eq 1 ]
-then
-  use_vnc=true
-fi
-
 
 # Process run_id
 # if it doesn't end in #, make sure that there is not another instance currently running with this same id

--- a/scripts/medley/medley_args.sh
+++ b/scripts/medley/medley_args.sh
@@ -412,9 +412,3 @@ do
   shift
 done
 
-# if running on WSL1, force use_vnc
-if [ "${wsl}" = true ] && [ "${wsl_ver}" -eq 1 ]
-then
-  use_vnc=true
-fi
-


### PR DESCRIPTION
Medley script currently forces -vnc when using WSL1.  This PR removes this infelicity.  The -vnc flag works the same on WSL1 as on other linuxes (including WSL2).