### PR TITLE
Fix online.interlisp.org/downloads/medley_downloads.html to reflect new wsl1 versus wsl2 ,releases (instead of just wsl)

### DIFF
--- a/installers/downloads_page/medley_downloads.html
+++ b/installers/downloads_page/medley_downloads.html
@@ -15,11 +15,16 @@
 <p><a href="@@@DOWNLOAD_URL@@@/medley-full-linux-aarch64-@@@COMBINED.RELEASE.TAG@@@.deb">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines</a></p>
 
 <p><a href="@@@DOWNLOAD_URL@@@/medley-full-linux-armv7l-@@@COMBINED.RELEASE.TAG@@@.deb">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARMv7 machines</a></p></li>
-<li><h4>Windows System for Linux</h4>
+<li><h4>Windows System for Linux v1</h4>
 
-<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl-x86_64-@@@COMBINED.RELEASE.TAG@@@.deb">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86.64 machines</a></p>
+<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl1-x86_64-@@@COMBINED.RELEASE.TAG@@@.deb">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86.64 machines</a></p>
 
-<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl-aarch64-@@@COMBINED.RELEASE.TAG@@@.deb">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines</a></p></li>
+<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl1-aarch64-@@@COMBINED.RELEASE.TAG@@@.deb">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines</a></p></li>
+<li><h4>Windows System for Linux v2</h4>
+
+<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl2-x86_64-@@@COMBINED.RELEASE.TAG@@@.deb">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86.64 machines</a></p>
+
+<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl2-aarch64-@@@COMBINED.RELEASE.TAG@@@.deb">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines</a></p></li>
 </ul></li>
 <li><h3>Local Installations (for any Linux distro)</h3>
 
@@ -31,11 +36,16 @@
 <p><a href="@@@DOWNLOAD_URL@@@/medley-full-linux-aarch64-@@@COMBINED.RELEASE.TAG@@@.tgz">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines</a></p>
 
 <p><a href="@@@DOWNLOAD_URL@@@/medley-full-linux-armv7l-@@@COMBINED.RELEASE.TAG@@@.tgz">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARMv7 machines</a></p></li>
-<li><h4>Windows System for Linux</h4>
+<li><h4>Windows System for Linux v1</h4>
 
-<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl-x86_64-@@@COMBINED.RELEASE.TAG@@@.tgz">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86_64 machines</a></p>
+<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl1-x86_64-@@@COMBINED.RELEASE.TAG@@@.tgz">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86_64 machines</a></p>
 
-<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl-aarch64-@@@COMBINED.RELEASE.TAG@@@.tgz">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines</a></p></li>
+<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl1-aarch64-@@@COMBINED.RELEASE.TAG@@@.tgz">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines</a></p></li>
+<li><h4>Windows System for Linux v2</h4>
+
+<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl2-x86_64-@@@COMBINED.RELEASE.TAG@@@.tgz">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86_64 machines</a></p>
+
+<p><a href="@@@DOWNLOAD_URL@@@/medley-full-wsl2-aarch64-@@@COMBINED.RELEASE.TAG@@@.tgz">Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines</a></p></li>
 </ul></li>
 </ul></li>
 <li><h2>WINDOWS 10/11 (Single install based on cygwin - Docker install deprecated)</h2>

--- a/installers/downloads_page/medley_downloads.md
+++ b/installers/downloads_page/medley_downloads.md
@@ -12,11 +12,17 @@
 
              [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARMv7 machines](@@@DOWNLOAD_URL@@@/medley-full-linux-armv7l-@@@COMBINED.RELEASE.TAG@@@.deb)
 
-             * #### Windows System for Linux
+             * #### Windows System for Linux v1
 
-             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86\.64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl-x86\_64-@@@COMBINED.RELEASE.TAG@@@.deb)
+             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86\.64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl1-x86\_64-@@@COMBINED.RELEASE.TAG@@@.deb)
 
-             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl-aarch64-@@@COMBINED.RELEASE.TAG@@@.deb)
+             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl1-aarch64-@@@COMBINED.RELEASE.TAG@@@.deb)
+
+             * #### Windows System for Linux v2
+
+             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86\.64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl2-x86\_64-@@@COMBINED.RELEASE.TAG@@@.deb)
+
+             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl2-aarch64-@@@COMBINED.RELEASE.TAG@@@.deb)
 
          *    ### Local Installations (for any Linux distro)
 
@@ -28,11 +34,17 @@
 
              [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARMv7 machines](@@@DOWNLOAD_URL@@@/medley-full-linux-armv7l-@@@COMBINED.RELEASE.TAG@@@.tgz)
 
-             * #### Windows System for Linux
+             * #### Windows System for Linux v1
 
-             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86\_64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl-x86\_64-@@@COMBINED.RELEASE.TAG@@@.tgz)
+             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86\_64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl1-x86\_64-@@@COMBINED.RELEASE.TAG@@@.tgz)
 
-             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl-aarch64-@@@COMBINED.RELEASE.TAG@@@.tgz)
+             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl1-aarch64-@@@COMBINED.RELEASE.TAG@@@.tgz)
+
+             * #### Windows System for Linux v2
+
+             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for x86\_64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl2-x86\_64-@@@COMBINED.RELEASE.TAG@@@.tgz)
+
+             [Release @@@MEDLEY.SHORT.RELEASE.TAG@@@ for ARM64 machines](@@@DOWNLOAD_URL@@@/medley-full-wsl2-aarch64-@@@COMBINED.RELEASE.TAG@@@.tgz)
 
      *    ## WINDOWS 10/11 (Single install based on cygwin - Docker install deprecated)
 


### PR DESCRIPTION
Recently split Medley releases for wsl into two seperate releases one for wsl1 and one for wsl2.  This change was not reflected in the https://online.interlisp.org/downloads/medley_downloads.html page.  This PR updates this page (or more properly the template from which this page is generated) to reflect this change in wsl releases.