### PR TITLE
Add deleted/* (from GITFNS) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ loadups/gitinfo
 *.sysout
 *.SYSOUT
 
+# GITFNS deleted subdirectory
+deleted/*
+
 #compiled code -- leave in for now
 
 # *.lcom

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ loadups/gitinfo
 *.SYSOUT
 
 # GITFNS deleted subdirectory
-deleted/*
+deleted/**
 
 #compiled code -- leave in for now
 


### PR DESCRIPTION
Only contains local information, and maybe just temporary.   (Maybe GITFNS should put it in {CORE}, but for now...)