### PR TITLE
Finish updating all Medley Github actions to account for deprecation of Node 20 on github runners

### DIFF
--- a/.github/workflows/buildDocker.yml
+++ b/.github/workflows/buildDocker.yml
@@ -170,7 +170,7 @@ jobs:
 
       # Setup the Docker Machine Emulation environment.  
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64
        # ,linux/arm64,linux/arm/v7
@@ -178,11 +178,11 @@ jobs:
       # Setup the Docker Buildx funtion
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Login into DockerHub - required to store the created image
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -191,7 +191,7 @@ jobs:
       # checked out and the release tars just downloaded.
       # Push the result to Docker Hub
       - name: Build Docker Image for Push to Docker Hub
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -221,11 +221,14 @@ jobs:
 
       # Push the release up to github releases
       - name: Delete existing release with same tag (if any)
-        uses: cb80/delrel@latest
-        with:
-            tag: ${{ env.MEDLEY_RELEASE_TAG }}
-        continue-on-error: true
-
+        run: |
+          gh release list --repo ${{ github.repository_owner }}/medley | grep ${{ env.MEDLEY_RELEASE_TAG }}
+          if [ $? -eq 0 ]
+          then
+            gh release delete ${{ env.MEDLEY_RELEASE_TAG }} --cleanup-tag --repo ${{ github.repository_owner }}/medley
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Push the release
         id: push
         uses: ncipollo/release-action@v1
@@ -243,7 +246,7 @@ jobs:
 
       # Save the tarball directory for subsequent jobs
       - name: Save tarballs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tarballs
           path: ${{ env.TARBALL_DIR }}
@@ -285,7 +288,7 @@ jobs:
 
       #  Get the tarballs
       - name: Get tarballs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tarballs
           path: ${{ env.TARBALL_DIR }}
@@ -319,7 +322,7 @@ jobs:
             mv  medley-full-linux-x86_64-*.tgz medley.tgz
 
       - name: Save medley tar for use in cygwin installers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: medley-tar
           path: |
@@ -366,7 +369,7 @@ jobs:
 
       #  Get the tarballs
       - name: Get tarballs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: tarballs
           path: ${{ env.TARBALL_DIR }}
@@ -437,7 +440,7 @@ jobs:
 
       # Retrieve medley tars from artifact store
       - name: Retrieve medley tar
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: medley-tar
           path: installers/cygwin/
@@ -616,7 +619,7 @@ jobs:
     steps:
       # Delete the tarballs artifact
       - name: Delete tarballs artifact
-        uses: geekyeggo/delete-artifact@v5
+        uses: geekyeggo/delete-artifact@v6
         with:
           name: tarballs
           failOnError: false

--- a/.github/workflows/buildLoadup.yml
+++ b/.github/workflows/buildLoadup.yml
@@ -222,6 +222,8 @@ jobs:
       # Push the release up to github releases
       - name: Delete existing release with same tag (if any)
         run: |
+          set +e
+          set +o pipefail
           gh release list --repo ${{ github.repository_owner }}/medley | grep ${{ env.MEDLEY_RELEASE_TAG }}
           if [ $? -eq 0 ]
           then


### PR DESCRIPTION
Updated or replaced remainder of calls to marketplace github actions to account for deprecation of Node 20 on github runners.  For most just updated version to latest released version.  For cb80/delrel, replaced with a shell script that deleted a tagged release using the gh cli (since cb80/delrel appears no longer active and is not being upgraded past Node 20).